### PR TITLE
STREAM-INF Redux (issue #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
 </div>
 
 # What is `masqueradarr`
+
+### **DISCORD** is the fastest way to find out exactly what is happening with this project. Tons of updates happening from community input.
+
 <div style="display:flex; justify-content:left; align-items:justify; gap:15px;">
     <a href="https://discord.gg/baD3HGpkcD">
       <img src="https://img.shields.io/badge/masqueradarr-join_discord-3F48AD?style=for-the-badge&logo=discord&logoSize=auto&link=https%3A%2F%2Fdiscord.gg%2FUEx4fEVwg4308EA8&labelColor=black" alt="Static Badge">
@@ -31,10 +34,9 @@
     <a>
       <img alt="Discord" src="https://img.shields.io/discord/1519879505886576690?style=for-the-badge&logo=discord&logoSize=auto&color=3F48AD&labelColor=black">
     </a>
-    
 </div>
 
-### [GitHub pages: masqueradarr](https://thebinaryninja.github.io/masqueradarr/)
+### [GitHub pages: masqueradarr](https://thebinaryninja.github.io/masqueradarr/) : Guides : Explanations : Documentation
 
 **masqueradarr** is a self-hosted IPTV aggregator. It pulls channel playlists (M3U) and guide
 data (EPG/XMLTV) from a range of online IPTV services, normalizes them into one catalog, and

--- a/compose/_global/m3u/bnadmin-x80u0m.m3u
+++ b/compose/_global/m3u/bnadmin-x80u0m.m3u
@@ -1,0 +1,2015 @@
+#EXTM3U x-tvg-url="http://localhost:3000/_global/epg/playlist.xml"
+#EXTINF:-1 tvg-id="400000096" tvg-name="A&E Crime 360" tvg-logo="https://canvas-lb.tubitv.com/opts/PkGioxw_qoRs4Q==/f96dfd36-d049-4c63-ae07-410f192f18b6/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",A&E Crime 360
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000096?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="618762" tvg-name="ABC News Live" tvg-logo="https://canvas-lb.tubitv.com/opts/UE7AlcHTNh1JbA==/a3419933-ef7c-435f-a963-10be102b0dcd/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",ABC News Live
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D618762?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000012" tvg-name="ACCDN" tvg-logo="https://canvas-lb.tubitv.com/opts/kRrxv36KIg9bPw==/8928da85-c7af-4da6-a0a1-9a32e3e5b2e8/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",ACCDN
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000012?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="692057" tvg-name="Alien Nation by DUST" tvg-logo="https://canvas-lb.tubitv.com/opts/t7SMobEbXiF0_Q==/48090b52-3410-4b0e-a2b1-7386e9700c1c/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Alien Nation by DUST
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D692057?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="653208" tvg-name="Always Funny" tvg-logo="https://canvas-lb.tubitv.com/opts/5dQ1izCyXmvqBg==/e8f543f1-3086-4896-a76e-20e86b782bd3/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Always Funny
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D653208?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000295" tvg-name="Always On: Alt Feeds | FIFA World Cup™ '26" tvg-logo="https://canvas-lb.tubitv.com/opts/7qSNHXFtmWebGw==/8fd7e5c9-2383-4d34-80ce-b41b5326c193/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Always On: Alt Feeds | FIFA World Cup™ '26
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000295?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="691129" tvg-name="America's Test Kitchen" tvg-logo="https://canvas-lb.tubitv.com/opts/W9ioP8rN2WZEdQ==/9804e812-0cda-4c43-b18e-ed951546a0b6/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",America's Test Kitchen
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D691129?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="682059" tvg-name="Anger Management" tvg-logo="https://canvas-lb.tubitv.com/opts/nDFPtoJN0b7OYw==/c327b06a-5844-429b-a4e1-36717181c962/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Anger Management
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D682059?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="694174" tvg-name="Antiques Road Trip" tvg-logo="https://canvas-lb.tubitv.com/opts/bgTisYfKI1IuqQ==/3ef7a392-9280-41c8-a8ca-a2a47f83c1d2/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Antiques Road Trip
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D694174?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="682057" tvg-name="Are We There Yet" tvg-logo="https://canvas-lb.tubitv.com/opts/2MzPjBx4XH-vJA==/620cc48a-a6d9-439e-8b38-f857a4ab2630/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Are We There Yet
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D682057?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715950" tvg-name="At the Movies" tvg-logo="https://canvas-lb.tubitv.com/opts/xAQ95D6WQgEvXg==/fa937ce5-3630-46c4-bdd6-e48132ffdd50/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",At the Movies
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715950?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000099" tvg-name="Ax Men" tvg-logo="https://canvas-lb.tubitv.com/opts/RruQnZmevLusfA==/279f34be-8b5c-42a1-a7df-e04f01e95693/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Ax Men
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000099?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000063" tvg-name="BBC Earth" tvg-logo="https://canvas-lb.tubitv.com/opts/KV6JQ9jiJwD74g==/630f09e9-a354-4d28-a952-2f5c75e09815/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",BBC Earth
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000063?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="653200" tvg-name="BUZZR" tvg-logo="https://canvas-lb.tubitv.com/opts/Q_Fd2Pw4-AIHqw==/078ff1ec-e958-4672-bf6b-6cad68c21b41/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",BUZZR
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D653200?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="653199" tvg-name="Baywatch" tvg-logo="https://canvas-lb.tubitv.com/opts/f_dPQDku21hHxw==/68173373-ff90-45ee-bf4d-d33e0f863770/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Baywatch
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D653199?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000119" tvg-name="Big 12 Studios" tvg-logo="https://canvas-lb.tubitv.com/opts/-0nmELSyfaWqNg==/eace1598-de1c-499a-8005-405d5cb5adb5/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Big 12 Studios
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000119?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="571664" tvg-name="Bloomberg Originals" tvg-logo="https://canvas-lb.tubitv.com/opts/LjcrdukJWSpYng==/0536c907-af63-40b6-a8d7-62c190492c5a/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Bloomberg Originals
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D571664?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555124" tvg-name="Bloomberg TV+" tvg-logo="https://canvas-lb.tubitv.com/opts/0L_dgCSAw6LQLg==/fde25048-c7d2-4bfb-b744-06755f42d915/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Bloomberg TV+
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555124?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="684164" tvg-name="Bounce XL" tvg-logo="https://canvas-lb.tubitv.com/opts/dpt9OiMYmCyhzw==/c5316804-bd82-46f4-81a4-289a8333cd71/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Bounce XL
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D684164?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000062" tvg-name="BritBox Mysteries" tvg-logo="https://canvas-lb.tubitv.com/opts/dn78f9-BM_rpCQ==/7d5c01ed-fb34-40c8-8c25-a56895e550f0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",BritBox Mysteries
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000062?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555130" tvg-name="CBC News" tvg-logo="https://canvas-lb.tubitv.com/opts/YMZxvZaVEX0HtA==/4de90f79-d72c-4016-a740-93916a615dc2/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",CBC News
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555130?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="673499" tvg-name="CINEVAULT" tvg-logo="https://canvas-lb.tubitv.com/opts/82sRW6C5W2iQ3w==/a5324ff4-3c3b-472f-b6e3-10d6e6e479c6/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",CINEVAULT
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D673499?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="673500" tvg-name="CINEVAULT: Classics" tvg-logo="https://canvas-lb.tubitv.com/opts/yeukiWgw3Zn-lQ==/07448ddf-973b-4340-8779-32376a973248/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",CINEVAULT: Classics
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D673500?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="673498" tvg-name="CINEVAULT: Westerns" tvg-logo="https://canvas-lb.tubitv.com/opts/1Kab-_4lb3EISw==/bda0dfca-9c16-4b67-8930-324a4b7a0dbd/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",CINEVAULT: Westerns
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D673498?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000074" tvg-name="Chasing Criminals" tvg-logo="https://canvas-lb.tubitv.com/opts/eRrzABhCqX5_Lw==/9f0a41fe-3e4d-44cf-ab49-e27914cdd8c1/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Chasing Criminals
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000074?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000092" tvg-name="Cheaters" tvg-logo="https://canvas-lb.tubitv.com/opts/td59qtLvlg-NcA==/1a61481a-60fa-4294-9d23-f097b7773866/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Cheaters
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000092?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555126" tvg-name="Cheddar" tvg-logo="https://canvas-lb.tubitv.com/opts/4Rv4zVMsE02xuA==/4975eac2-9902-4ac5-8036-f28a6d9979a0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Cheddar
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555126?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000028" tvg-name="Cine EstrellaTV" tvg-logo="https://canvas-lb.tubitv.com/opts/9OVEbAJcKG4LlA==/f19b2e05-e9f9-402a-89bb-955a1559d984/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Cine EstrellaTV
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000028?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000069" tvg-name="Classic Cinema" tvg-logo="https://canvas-lb.tubitv.com/opts/XVod67K_ugYtJw==/0e4ed995-2f32-48bb-a0f5-c0082c66f37e/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Classic Cinema
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000069?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000059" tvg-name="Classic Doctor Who" tvg-logo="https://canvas-lb.tubitv.com/opts/xKIf6J3HCq8sfQ==/2d6dbfc0-0fca-4d2c-abcc-bce692499401/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Classic Doctor Who
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000059?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000085" tvg-name="Cold Case Files" tvg-logo="https://canvas-lb.tubitv.com/opts/2sFOpuolp9lAjA==/1741bc33-42d6-4044-8584-c7875bba243c/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Cold Case Files
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000085?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000169" tvg-name="Comedy Dynamics" tvg-logo="https://canvas-lb.tubitv.com/opts/uYKuLYyiz2HNxA==/bcc2221d-8150-4301-8c6b-98504d781641/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Comedy Dynamics
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000169?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000299" tvg-name="Court TV" tvg-logo="https://canvas-lb.tubitv.com/opts/Ab-35uOZbQzi-g==/7f11ea05-473c-46dc-abbd-93ada2196c7d/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Court TV
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000299?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000285" tvg-name="Cowboy+ Sports" tvg-logo="https://canvas-lb.tubitv.com/opts/u4W97Evqtq5RMQ==/3f8686fa-f328-4833-a8f1-c055986fdcdd/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Cowboy+ Sports
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000285?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000095" tvg-name="Crime Cults Killers" tvg-logo="https://canvas-lb.tubitv.com/opts/BdCf_2WU9Nzvbw==/12e83781-4ab1-491a-826e-8b968c78ec32/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Crime Cults Killers
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000095?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715949" tvg-name="Crime Scenes" tvg-logo="https://canvas-lb.tubitv.com/opts/HsA80vuoV4SktQ==/4f7b9117-d773-4dbc-a9e2-4bb77bae1126/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Crime Scenes
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715949?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000090" tvg-name="Crime ThrillHer" tvg-logo="https://canvas-lb.tubitv.com/opts/yTUdTHkxF1KzGQ==/9d6112c8-c0fb-4179-aa34-4025c0153b14/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Crime ThrillHer
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000090?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000024" tvg-name="DAZN Ringside" tvg-logo="https://canvas-lb.tubitv.com/opts/P5khntngIx0W_w==/aa1f99f5-7a57-44a1-b031-b3a27eceab13/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",DAZN Ringside
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000024?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000086" tvg-name="Dance Moms" tvg-logo="https://canvas-lb.tubitv.com/opts/LG699URBRLDqOQ==/35803cea-97e6-487c-9050-0171abf6c647/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Dance Moms
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000086?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="711410" tvg-name="Dateline 24/7" tvg-logo="https://canvas-lb.tubitv.com/opts/acReNIzwC2WiuA==/32d8bd46-4cc6-4f9b-8db3-694be23ed0e3/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Dateline 24/7
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D711410?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000098" tvg-name="Deal Zone" tvg-logo="https://canvas-lb.tubitv.com/opts/rb2kTcyckd-Ltg==/982ab39c-a6a8-472b-9210-3b009956dee1/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Deal Zone
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000098?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="670604" tvg-name="Deal or No Deal USA" tvg-logo="https://canvas-lb.tubitv.com/opts/g7byDgzsOUbQNA==/78811e2c-60c2-4e88-ac2b-c083848b67ce/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Deal or No Deal USA
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D670604?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000117" tvg-name="Def Jam" tvg-logo="https://canvas-lb.tubitv.com/opts/ADqkOoAZL-RKoA==/a95b393f-af18-4bb2-b5cd-bab323fd961f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Def Jam
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000117?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000108" tvg-name="Discovery Turbo TV" tvg-logo="https://canvas-lb.tubitv.com/opts/TA-WoDn6tYKtCQ==/e1fddeac-4117-45e8-a880-d46000b4fcda/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Discovery Turbo TV
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000108?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000088" tvg-name="Dog the Bounty Hunter" tvg-logo="https://canvas-lb.tubitv.com/opts/Er-hEK6ElFu0BA==/d81a47a9-92b7-403c-b65b-d4153a9ebefd/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Dog the Bounty Hunter
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000088?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="724209" tvg-name="Dr. G: Medical Examiner" tvg-logo="https://canvas-lb.tubitv.com/opts/XJg57cG_3nPP0w==/eb9609d4-9dc0-4460-b61e-0b992ec14668/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Dr. G: Medical Examiner
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D724209?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000087" tvg-name="Duck Dynasty" tvg-logo="https://canvas-lb.tubitv.com/opts/27B0TzReARo-SQ==/f2f4da49-e449-451e-a1e2-1abf11dcfcf9/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Duck Dynasty
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000087?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000056" tvg-name="Ebony TV by Lionsgate" tvg-logo="https://canvas-lb.tubitv.com/opts/yHCUm2mwp3Y8yw==/6ff20b44-04d5-426c-aaf5-5593a6c60b87/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Ebony TV by Lionsgate
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000056?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000030" tvg-name="Estrella Games" tvg-logo="https://canvas-lb.tubitv.com/opts/99D3V0iTFxlbbw==/24f67f95-6f5f-4db9-8e06-bd7227bcd1c9/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Estrella Games
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000030?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="560215" tvg-name="Estrella News" tvg-logo="https://canvas-lb.tubitv.com/opts/7P1PhF9IBvHjcw==/6693c612-32f8-4e02-be56-0029a4576cb2/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Estrella News
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D560215?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000031" tvg-name="EstrellaTV" tvg-logo="https://canvas-lb.tubitv.com/opts/zrY0UyOyECLncA==/529ef58f-5297-4ba3-8373-cc5efdd68a65/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",EstrellaTV
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000031?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="559144" tvg-name="Euronews" tvg-logo="https://canvas-lb.tubitv.com/opts/9sem5esRDztU_g==/bac08913-5ae4-4e98-8a24-18f143bd6e25/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Euronews
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D559144?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555118" tvg-name="FOX 2 Detroit" tvg-logo="https://canvas-lb.tubitv.com/opts/6wedfRuxayjJQQ==/ce338343-c4ac-490a-b715-54f3b46c84ae/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FOX 2 Detroit
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555118?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555113" tvg-name="FOX LOCAL Los Angeles" tvg-logo="https://canvas-lb.tubitv.com/opts/oC-hI5oCZJUiBA==/0e73f3ca-3e7a-4fa9-82e2-cefdfb798fef/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FOX LOCAL Los Angeles
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555113?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555119" tvg-name="FOX LOCAL New York" tvg-logo="https://canvas-lb.tubitv.com/opts/bKxO2pZFIwBisA==/c6c25ba1-c2fd-4e78-973f-3a220337f694/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FOX LOCAL New York
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555119?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555121" tvg-name="FOX LOCAL Washington DC" tvg-logo="https://canvas-lb.tubitv.com/opts/_jvGWcGqFs6DhQ==/8c560c21-a9f7-41c7-82ad-df5674fb9692/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FOX LOCAL Washington DC
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555121?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555382" tvg-name="FOX SOUL" tvg-logo="https://canvas-lb.tubitv.com/opts/RL-qLG_anSeyOg==/bbbed8f2-f666-49ad-8288-03f049585e3d/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FOX SOUL
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555382?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="613683" tvg-name="FOX Sports on Tubi" tvg-logo="https://canvas-lb.tubitv.com/opts/50bQ3M9R_pEUzg==/69e052e9-4264-45cf-93f6-6218f998abc4/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FOX Sports on Tubi
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D613683?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="628893" tvg-name="FOX Weather" tvg-logo="https://canvas-lb.tubitv.com/opts/GnNXSUczAo3hrg==/ac3a8a9b-0068-488b-a5c6-380f373cc446/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FOX Weather
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D628893?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000289" tvg-name="FailArmy" tvg-logo="https://canvas-lb.tubitv.com/opts/VuPsFP8P0bwjzg==/79c97537-0288-43e3-8d3d-d9aa37591d9c/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FailArmy
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000289?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000196" tvg-name="Family Feud" tvg-logo="https://canvas-lb.tubitv.com/opts/dTQldekProaESw==/d94cfde1-49a9-4a2b-ab4f-a2848db4a588/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Family Feud
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000196?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715948" tvg-name="Family Unscripted" tvg-logo="https://canvas-lb.tubitv.com/opts/g-TnN7dezapq7Q==/6ea6276d-0cdb-4348-a68f-5b6cc575c8cb/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Family Unscripted
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715948?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000100" tvg-name="FanDuel TV Extra" tvg-logo="https://canvas-lb.tubitv.com/opts/8oKNxG1sMyljIw==/033a7701-c6ef-42be-a66e-b517d36a83e1/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FanDuel TV Extra
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000100?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="670602" tvg-name="Fear Factor USA" tvg-logo="https://canvas-lb.tubitv.com/opts/lnF_d9-y39CI8A==/ae22b756-ab2a-4cb2-bb18-ce281b110449/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Fear Factor USA
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D670602?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="692087" tvg-name="FilmRise Black TV" tvg-logo="https://canvas-lb.tubitv.com/opts/iSjLnTm143Vo_g==/d4f0575b-389c-47f7-83c8-ce2a262ee072/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FilmRise Black TV
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D692087?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="692090" tvg-name="FilmRise Horror" tvg-logo="https://canvas-lb.tubitv.com/opts/VTj8tXffeMV_hA==/954da076-c0e7-4560-9d3a-87f4bcfd3bf3/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FilmRise Horror
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D692090?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="692086" tvg-name="FilmRise True Crime" tvg-logo="https://canvas-lb.tubitv.com/opts/MAvFbEtOgtMRIQ==/83aa1731-c6a7-42d6-b797-1d2210b665ec/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",FilmRise True Crime
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D692086?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="671083" tvg-name="Forensic Files" tvg-logo="https://canvas-lb.tubitv.com/opts/zLoOXSCJ53buRQ==/cede5a8f-240c-4790-bd37-e1e51583cd0c/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Forensic Files
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D671083?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="613695" tvg-name="Fox Sports En Español" tvg-logo="https://canvas-lb.tubitv.com/opts/Rt5VK8q8c6pWvw==/c2e45f1a-4b72-41fa-ac6c-4e402ca4d4f6/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Fox Sports En Español
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D613695?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="557344" tvg-name="Fubo Sports Network" tvg-logo="https://canvas-lb.tubitv.com/opts/ADINZ0CxEk4Nzg==/134cd1d6-d194-49e9-a057-076ea9c0947d/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Fubo Sports Network
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D557344?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000284" tvg-name="Futcrunch" tvg-logo="https://canvas-lb.tubitv.com/opts/eI1d7cSPZQFhOQ==/67bea288-0819-444f-80ed-33c65e5fc502/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Futcrunch
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000284?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="673411" tvg-name="Game Show Central" tvg-logo="https://canvas-lb.tubitv.com/opts/ZiXULUiKSeFNHQ==/6f7f3b3f-a050-4254-82eb-2c705dab77a6/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Game Show Central
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D673411?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="700407" tvg-name="Garden with Monty Don" tvg-logo="https://canvas-lb.tubitv.com/opts/pMAu7mxETSJVkA==/65c6d925-e66f-49a2-88fd-2d8e323ccef9/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Garden with Monty Don
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D700407?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000070" tvg-name="Generation Drama" tvg-logo="https://canvas-lb.tubitv.com/opts/95HEwdQAa2iY7A==/6e4b7a38-ccc1-4f1f-b4ce-626221c91a06/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Generation Drama
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000070?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715951" tvg-name="Ghosts are Real" tvg-logo="https://canvas-lb.tubitv.com/opts/RkmPNUN41gLzWg==/f0784641-0d22-4eb3-88a2-f2854aa235f9/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Ghosts are Real
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715951?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="677011" tvg-name="Gordon Ramsay" tvg-logo="https://canvas-lb.tubitv.com/opts/zBCOxZ6hwxcgWg==/f7eea1c7-409e-4abc-b6f3-1228bb7135d7/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Gordon Ramsay
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D677011?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="684170" tvg-name="Grit Xtra" tvg-logo="https://canvas-lb.tubitv.com/opts/aBwIuhHsOE8fLQ==/9ba330f3-9b7c-436d-9eb3-ca24daeaa59a/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Grit Xtra
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D684170?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000083" tvg-name="HBO Boxing" tvg-logo="https://canvas-lb.tubitv.com/opts/WGHcNsnAV2ZzZQ==/85396ad7-4f62-4df1-a6a6-433b0e027106/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",HBO Boxing
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000083?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000164" tvg-name="Hagerty" tvg-logo="https://canvas-lb.tubitv.com/opts/m139XSbqHN7igw==/63cd15f5-1b92-44ec-aa48-da4c4f90fb8f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Hagerty
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000164?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="700406" tvg-name="HauntTV" tvg-logo="https://canvas-lb.tubitv.com/opts/wHbytimRWEDg5w==/a9501720-74af-489c-993e-8c38c438e058/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",HauntTV
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D700406?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000104" tvg-name="Hersphere" tvg-logo="https://canvas-lb.tubitv.com/opts/xP0esskgVLQXMA==/2733aed8-2c07-4221-9669-061ef85c0df0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Hersphere
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000104?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="700414" tvg-name="Homeful" tvg-logo="https://canvas-lb.tubitv.com/opts/Mk_URWBFrOnFUw==/790ebde9-0938-4667-9664-62136298f868/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Homeful
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D700414?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="692051" tvg-name="Horror by ALTER" tvg-logo="https://canvas-lb.tubitv.com/opts/9JeV0i6F9xtz4w==/f4523b29-6b4d-4b40-ae37-5ff4f79691c5/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Horror by ALTER
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D692051?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715952" tvg-name="How To" tvg-logo="https://canvas-lb.tubitv.com/opts/762KTCjtPl2nNw==/e7c157ef-0e36-4131-9218-f27076ce26f4/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",How To
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715952?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="682634" tvg-name="ION" tvg-logo="https://canvas-lb.tubitv.com/opts/LFLNras1Iw825A==/d7bf80e8-e8bc-4883-9c2b-551d1d7ab80c/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",ION
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D682634?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="684167" tvg-name="ION Mystery" tvg-logo="https://canvas-lb.tubitv.com/opts/L4MwA9dYDyiUSg==/b74f76d9-1cd3-4ff8-861a-c4613ef3ca3e/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",ION Mystery
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D684167?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="684165" tvg-name="ION Plus" tvg-logo="https://canvas-lb.tubitv.com/opts/i_iUUrOlkunMhA==/979fd7e0-d2df-4c2b-90d0-af690c9405cb/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",ION Plus
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D684165?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000089" tvg-name="Ice Road Truckers" tvg-logo="https://canvas-lb.tubitv.com/opts/Oav7vVDh-LuKdA==/7655be2e-e1c5-43f2-92b3-fad5c753777e/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Ice Road Truckers
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000089?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000073" tvg-name="In the Garage" tvg-logo="https://canvas-lb.tubitv.com/opts/i8bjHzfbFfhq1A==/8ec6200b-cbe1-4e2b-9883-24a37f5f4ab7/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",In the Garage
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000073?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000296" tvg-name="Jesser" tvg-logo="https://canvas-lb.tubitv.com/opts/f0Sr69MF832Sjg==/70ee8b58-bb2f-4860-95a4-cc78382fd3be/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Jesser
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000296?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000287" tvg-name="Jubilee" tvg-logo="https://canvas-lb.tubitv.com/opts/WXg--EMARkp8-A==/65c250e3-cda5-4181-b7d2-94be0ae1a88f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Jubilee
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000287?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="644787" tvg-name="KARE Minneapolis 11" tvg-logo="https://canvas-lb.tubitv.com/opts/AWxb56ox5eXCvw==/2c79ec3a-39b0-41cd-82e3-18b1bacd9eba/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",KARE Minneapolis 11
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D644787?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="687455" tvg-name="KBZK News Bozeman" tvg-logo="https://canvas-lb.tubitv.com/opts/ICxvJpjBxB91cg==/4cdba71e-4655-4162-8cbe-9b61fcb2b1cb/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",KBZK News Bozeman
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D687455?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="586035" tvg-name="KETV Very Omaha 7" tvg-logo="https://canvas-lb.tubitv.com/opts/isuXic7iLnf0Bg==/68e6bca8-e2d7-4615-8a29-531224c606ff/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",KETV Very Omaha 7
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D586035?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="603178" tvg-name="KMGH Denver 7+ News" tvg-logo="https://canvas-lb.tubitv.com/opts/Wip8wYzIID6ipg==/bf147be9-a73f-4512-a28d-cf3429b8b83b/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",KMGH Denver 7+ News
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D603178?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000033" tvg-name="Kartoon Channel!" tvg-logo="https://canvas-lb.tubitv.com/opts/_oaMTbqkvgy0VA==/4258e598-4722-409b-8e3c-625f800ba9ba/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Kartoon Channel!
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000033?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="692114" tvg-name="LOL! Network" tvg-logo="https://canvas-lb.tubitv.com/opts/Y7HgrFc8PhNT3w==/cedecff3-9f15-4dbe-b883-ff156a2ecca5/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",LOL! Network
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D692114?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000251" tvg-name="Law&Crime" tvg-logo="https://canvas-lb.tubitv.com/opts/BYzaJwTCsR4qOQ==/d4c950c6-5131-47a1-a52b-f0644e28d89a/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Law&Crime
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000251?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555127" tvg-name="LiveNOW from FOX" tvg-logo="https://canvas-lb.tubitv.com/opts/T8yaEtMuJkd6MA==/f71c682e-37f8-4719-aa89-546d1c4c8bfe/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",LiveNOW from FOX
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555127?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000067" tvg-name="Living with Evil" tvg-logo="https://canvas-lb.tubitv.com/opts/edxSmlIDu3pWYA==/e4f84ab2-4935-4063-ad29-cc852b91e3b7/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Living with Evil
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000067?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="618763" tvg-name="Localish" tvg-logo="https://canvas-lb.tubitv.com/opts/IsFWFfNoNmVF-A==/577b5b8e-307a-4535-a8fc-e18563a11950/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Localish
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D618763?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715947" tvg-name="Love & Marriage" tvg-logo="https://canvas-lb.tubitv.com/opts/QVwlsOJ3Ig8OfA==/7b9a7209-d8b1-4c1e-9132-0407a473ed8f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Love & Marriage
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715947?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="700418" tvg-name="Love Nature" tvg-logo="https://canvas-lb.tubitv.com/opts/0iGeAKWjBWGBjg==/1c502e7b-e295-4f49-a248-cbe59b17d0f1/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Love Nature
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D700418?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="613765" tvg-name="MLB" tvg-logo="https://canvas-lb.tubitv.com/opts/6tImLu773-5D_g==/652d017f-fb2a-460e-a528-ee54cc6ed872/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",MLB
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D613765?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="692262" tvg-name="Maverick Black Cinema" tvg-logo="https://canvas-lb.tubitv.com/opts/AkqKzseBA2rFdw==/15ddd8ef-f96c-43eb-9640-673f573d4eeb/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Maverick Black Cinema
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D692262?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="700415" tvg-name="Midsomer Murders" tvg-logo="https://canvas-lb.tubitv.com/opts/o7f7K74UmcLArw==/34fa2e5d-6c68-4012-8c19-cc4afe6ad726/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Midsomer Murders
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D700415?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="670587" tvg-name="MovieSphere" tvg-logo="https://canvas-lb.tubitv.com/opts/ijTE2umz9Uhwbw==/262557d9-a277-464c-b915-e200128f48a0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",MovieSphere
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D670587?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000048" tvg-name="MrBeast" tvg-logo="https://canvas-lb.tubitv.com/opts/Mndf9fhZSCab_w==/1cd9fa65-16d9-40e6-81c3-a81ce2663736/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",MrBeast
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000048?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715946" tvg-name="Mysterious Worlds" tvg-logo="https://canvas-lb.tubitv.com/opts/CqSYtT2lYvQOPQ==/686ca4a9-30ac-42d6-bdbf-70199f7912d9/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Mysterious Worlds
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715946?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="656575" tvg-name="Mystery Science Theater 3000" tvg-logo="https://canvas-lb.tubitv.com/opts/g-dtAd_wR8w64w==/62dc5afa-c235-41ae-904e-e77b6c93e93e/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Mystery Science Theater 3000
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D656575?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000290" tvg-name="Mythical 24/7" tvg-logo="https://canvas-lb.tubitv.com/opts/2mcvzKqRwgNrrg==/5a6b6a83-e437-41c9-a130-ebdde2b4665e/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Mythical 24/7
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000290?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000121" tvg-name="NASCAR" tvg-logo="https://canvas-lb.tubitv.com/opts/1hBihc5u12jjfA==/7739dd1a-423d-4a56-92c7-d27129356eb0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",NASCAR
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000121?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="556174" tvg-name="NBC News NOW" tvg-logo="https://canvas-lb.tubitv.com/opts/1MnyiPLY889fxg==/dd770066-df10-4187-b8d5-c31d0b9c0a1f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",NBC News NOW
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D556174?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="613761" tvg-name="NFL Channel" tvg-logo="https://canvas-lb.tubitv.com/opts/MWTjzbz0C0Irrw==/7bffc557-8e66-4b08-b279-55ece734e19f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",NFL Channel
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D613761?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000008" tvg-name="NHL" tvg-logo="https://canvas-lb.tubitv.com/opts/8h7HYVpDz2amhw==/085bca04-c806-4a7f-bb0c-d38fe352f3e3/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",NHL
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000008?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="629323" tvg-name="NHRA TV" tvg-logo="https://canvas-lb.tubitv.com/opts/IqXIAd_1YjDrjA==/20c45879-2263-415e-8d68-2f5522c6ba81/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",NHRA TV
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D629323?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000105" tvg-name="Nash Bridges" tvg-logo="https://canvas-lb.tubitv.com/opts/WNnMH6qKRZWqEw==/13cb369b-10c8-4017-82f6-3658ff67b899/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Nash Bridges
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000105?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="557345" tvg-name="News 12 New York" tvg-logo="https://canvas-lb.tubitv.com/opts/M-fGOgFir4-mLQ==/08fde41e-4252-484f-8b51-17124415b90c/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",News 12 New York
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D557345?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000071" tvg-name="Nikita" tvg-logo="https://canvas-lb.tubitv.com/opts/-Qup7p-9U8QS9Q==/bf6f69f6-4495-4bc2-94f9-fd91877e36f0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Nikita
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000071?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="641492" tvg-name="Nosey" tvg-logo="https://canvas-lb.tubitv.com/opts/dGh54TTvBjR7DQ==/22eaf49e-a2ad-4da4-afbd-66aedb72c78f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Nosey
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D641492?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000006" tvg-name="OuterSphere" tvg-logo="https://canvas-lb.tubitv.com/opts/z5KrO42O-7nU4A==/9d4070e4-10ea-42f7-8598-d56da77c07e0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",OuterSphere
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000006?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000046" tvg-name="PGA TOUR" tvg-logo="https://canvas-lb.tubitv.com/opts/-1nseJGZfQ7nOQ==/168854e2-e698-4fee-8e2a-5e21c7b278c4/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",PGA TOUR
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000046?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000157" tvg-name="PLL Network" tvg-logo="https://canvas-lb.tubitv.com/opts/ePzKM5wASsCWaw==/c41d5617-9035-4146-bafa-be2d9de2968c/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",PLL Network
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000157?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000292" tvg-name="Paternity Court by MGM" tvg-logo="https://canvas-lb.tubitv.com/opts/Y4bN1fFARdGeEg==/66d0923c-164a-4279-a199-206a054e98d9/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Paternity Court by MGM
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000292?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715939" tvg-name="Paws & Claws" tvg-logo="https://canvas-lb.tubitv.com/opts/Xy_fFJ2HP2eLiA==/9aa4b3ac-db29-4a50-9c78-973cdeb2bed6/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Paws & Claws
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715939?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000045" tvg-name="PokerGO" tvg-logo="https://canvas-lb.tubitv.com/opts/MBvtJt_BcDScDg==/3a6b2ab5-d20e-4b25-9231-65bc11c8b3c0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",PokerGO
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000045?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="641290" tvg-name="REELZ Famous & Infamous" tvg-logo="https://canvas-lb.tubitv.com/opts/ugZA0exwfgSpHA==/942bdeac-9411-4562-a78c-5402d04711a7/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",REELZ Famous & Infamous
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D641290?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="613762" tvg-name="Real Madrid" tvg-logo="https://canvas-lb.tubitv.com/opts/0eZIOEWFj-zM3A==/4bb7bdf1-16ba-4d7c-b077-893f549c4022/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Real Madrid
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D613762?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="578086" tvg-name="Scripps News" tvg-logo="https://canvas-lb.tubitv.com/opts/W-Z-xUm9GB3tRQ==/d7933070-b9eb-4ce4-9c59-9631dd5815be/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Scripps News
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D578086?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000286" tvg-name="Scripps Sports Network" tvg-logo="https://canvas-lb.tubitv.com/opts/bee-OUuto3TH9w==/73b2cd96-916d-4081-b14f-c6f503ebf2be/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Scripps Sports Network
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000286?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000064" tvg-name="Silent Witness and New Tricks" tvg-logo="https://canvas-lb.tubitv.com/opts/dt0VWOtvi4zTRw==/2601f920-7f1b-4a8f-a583-00b77ede189e/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Silent Witness and New Tricks
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000064?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="613763" tvg-name="Stadium" tvg-logo="https://canvas-lb.tubitv.com/opts/-NtXXHY5Foetwg==/ffec7159-bf94-4c51-9544-5162e5a57b2f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Stadium
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D613763?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="658748" tvg-name="Supermarket Sweep" tvg-logo="https://canvas-lb.tubitv.com/opts/6EKdmQaAAptSmQ==/5a1c3037-9440-4644-a0fd-489d5554ff1c/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Supermarket Sweep
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D658748?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715938" tvg-name="Sweet Escapes" tvg-logo="https://canvas-lb.tubitv.com/opts/FZ3_BVJbTDY7uA==/db730c00-68a8-4147-bbab-a07b081c3179/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Sweet Escapes
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715938?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="641496" tvg-name="TMZ" tvg-logo="https://canvas-lb.tubitv.com/opts/5NTa5Ekxbl8G0w==/ac6425fe-0808-4566-ba6a-066d22dc3829/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",TMZ
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D641496?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000011" tvg-name="TV One Crime & Justice" tvg-logo="https://canvas-lb.tubitv.com/opts/RSur1I_YA1It6Q==/bed0ab9e-637e-4b96-a808-ee8b748c563f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",TV One Crime & Justice
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000011?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000247" tvg-name="TV One Stars & Stories" tvg-logo="https://canvas-lb.tubitv.com/opts/sxMfiz-fW1hSIg==/38c3d087-46de-4c79-8b12-763f4483af0d/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",TV One Stars & Stories
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000247?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="677790" tvg-name="The Biggest Loser" tvg-logo="https://canvas-lb.tubitv.com/opts/-ZIKP2u6RaYLoA==/d15c6bd1-7006-4386-beff-047dfe28d2d2/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Biggest Loser
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D677790?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="660350" tvg-name="The Bob Ross Channel" tvg-logo="https://canvas-lb.tubitv.com/opts/rqdPpoz_b6nrWQ==/f5c01303-17e6-44a4-826e-d03be6b05d10/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Bob Ross Channel
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D660350?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000155" tvg-name="The Breakfast Club on iHeartRadio" tvg-logo="https://canvas-lb.tubitv.com/opts/5MVh3_mmQ1OFyA==/fa2f8c60-0492-4a50-a92d-4a034e9f89f3/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Breakfast Club on iHeartRadio
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000155?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="656574" tvg-name="The Carol Burnett Show" tvg-logo="https://canvas-lb.tubitv.com/opts/G7pEsTRNoRelrA==/0de31780-db48-47ea-9279-955ddaa089b5/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Carol Burnett Show
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D656574?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000103" tvg-name="The Conners" tvg-logo="https://canvas-lb.tubitv.com/opts/le71z1hR2zy5vA==/2519aeef-b530-4f17-b7e7-16dfce1f1bd0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Conners
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000103?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000066" tvg-name="The FBI" tvg-logo="https://canvas-lb.tubitv.com/opts/aHkRMXjL2FQbvg==/44ac2d3a-3a63-46f3-badb-fe3f8afa7600/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The FBI
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000066?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000091" tvg-name="The FBI Files" tvg-logo="https://canvas-lb.tubitv.com/opts/b_lV2vB1BiPx6A==/56b0a95e-2750-408d-9059-2c4c170e7dca/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The FBI Files
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000091?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="702891" tvg-name="The Jack Hanna Channel" tvg-logo="https://canvas-lb.tubitv.com/opts/3wf3jsnrOoz-Dw==/4151b64f-afe8-4eb0-9f5a-82865d67d89d/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Jack Hanna Channel
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D702891?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="658746" tvg-name="The Johnny Carson Show" tvg-logo="https://canvas-lb.tubitv.com/opts/AIgk5Ch_-sbsfQ==/c468221e-d75c-428a-bfaa-cdb5277c4c3b/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Johnny Carson Show
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D658746?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="650666" tvg-name="The Masked Singer" tvg-logo="https://canvas-lb.tubitv.com/opts/WIbXszK-dwWtwA==/ff6398da-6988-4b07-85ed-d732eb70b6aa/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Masked Singer
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D650666?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000116" tvg-name="The NBA Channel" tvg-logo="https://canvas-lb.tubitv.com/opts/VGJpYUttk1EYXg==/7d258341-afc7-4022-acd4-ce330c6db573/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The NBA Channel
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000116?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000288" tvg-name="The Pet Collective" tvg-logo="https://canvas-lb.tubitv.com/opts/NVl_sd1MZhcwUQ==/21f728d8-3f2f-4681-a331-413b1eb68f48/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Pet Collective
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000288?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000249" tvg-name="The Price Is Right: The Barker Era" tvg-logo="https://canvas-lb.tubitv.com/opts/DY24HIrk-TRckg==/7c1bdfbc-0f08-4323-8737-5e90b6a0a0ac/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Price Is Right: The Barker Era
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000249?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="724210" tvg-name="The Rifleman" tvg-logo="https://canvas-lb.tubitv.com/opts/U7cdfxf2EiPC5A==/e80bdb91-a817-463c-84b6-f3e4be903428/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",The Rifleman
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D724210?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="597678" tvg-name="Today All Day" tvg-logo="https://canvas-lb.tubitv.com/opts/evVIud42yl9aiQ==/bf04720c-d113-4728-a69a-a0ebc800e7b3/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Today All Day
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D597678?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000112" tvg-name="Todo Cine" tvg-logo="https://canvas-lb.tubitv.com/opts/JdxWUYI3KdZp6Q==/2f1836dd-96a2-4baa-a7ef-786f38eb09c6/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Todo Cine
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000112?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000111" tvg-name="Todo Novelas más Pasiones" tvg-logo="https://canvas-lb.tubitv.com/opts/Vjr6YqpmQHQ7TA==/084d9109-dc3a-43af-913c-2df986999dd5/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Todo Novelas más Pasiones
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000111?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000065" tvg-name="Top Gear" tvg-logo="https://canvas-lb.tubitv.com/opts/fKfb6sHtpwnuig==/45d06aa3-8a80-4864-a7b0-25a606d26be3/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Top Gear
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000065?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000055" tvg-name="Top Rank Classics" tvg-logo="https://canvas-lb.tubitv.com/opts/MIna_NLcBGTgIw==/9ecc2de5-5b17-4d2e-a407-ced0d00af082/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Top Rank Classics
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000055?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000097" tvg-name="Torque" tvg-logo="https://canvas-lb.tubitv.com/opts/IB-MqRJoj39PYw==/8c846b53-83bc-4c0b-a9c0-ff323c46c057/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Torque
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000097?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="700412" tvg-name="Total Crime" tvg-logo="https://canvas-lb.tubitv.com/opts/o-H1LgfSug5Osg==/7e8b8518-8447-4c08-9193-55efa2fff3bc/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Total Crime
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D700412?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000068" tvg-name="Travel + Adventure" tvg-logo="https://canvas-lb.tubitv.com/opts/dnrWe24DU2G4iw==/d2ad86e1-c1b3-4758-abec-a75aabd439d0/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Travel + Adventure
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000068?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000106" tvg-name="UFC" tvg-logo="https://canvas-lb.tubitv.com/opts/SImeAOgOma8YLQ==/a2adde61-ad0b-49bd-bf32-ec660546a380/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",UFC
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000106?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000094" tvg-name="UnXplained Zone" tvg-logo="https://canvas-lb.tubitv.com/opts/2U-aZ93Ctd_a2A==/dfdffa87-f1cf-4849-baab-6d55e3c3f3d6/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",UnXplained Zone
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000094?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715942" tvg-name="Unique Lives" tvg-logo="https://canvas-lb.tubitv.com/opts/m9EWLVua_xh2VQ==/a7d3ffc6-0efb-4136-9faf-1be405d7a9dd/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Unique Lives
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715942?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="671073" tvg-name="Unsolved Mysteries" tvg-logo="https://canvas-lb.tubitv.com/opts/aKYeZc2Iq7NuYQ==/864892f9-3ab0-4950-9f8b-189ec2d92c20/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Unsolved Mysteries
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D671073?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000179" tvg-name="Untold Stories of the E.R." tvg-logo="https://canvas-lb.tubitv.com/opts/bf8d-EFeffQoaA==/cdb009e8-90ea-4ef5-b12e-9395702b4a17/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Untold Stories of the E.R.
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000179?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000195" tvg-name="Vice" tvg-logo="https://canvas-lb.tubitv.com/opts/cCQXX0wwG-Dgaw==/bf6dfcde-342c-4803-9bf0-de17bdde3853/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Vice
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000195?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="603904" tvg-name="WESH Very Orlando 2" tvg-logo="https://canvas-lb.tubitv.com/opts/UlfBN5Zw_XwBsA==/9472475f-b199-47e0-b493-c8e157d17817/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",WESH Very Orlando 2
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D603904?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="603918" tvg-name="WMOR Very Tampa Bay 32" tvg-logo="https://canvas-lb.tubitv.com/opts/A86zp-VaAK5BBw==/677269c0-5f19-4be5-ab87-7ab451565d5e/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",WMOR Very Tampa Bay 32
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D603918?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="688992" tvg-name="WSYM FOX 47 News Lansing" tvg-logo="https://canvas-lb.tubitv.com/opts/rXmNtjT0O2eLWg==/962acff1-2c98-483d-ac76-bb5713c41524/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",WSYM FOX 47 News Lansing
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D688992?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="677785" tvg-name="WXMI FOX 17 West Michigan" tvg-logo="https://canvas-lb.tubitv.com/opts/CE2AwcjIeOv_Ug==/9c9a4875-7b0a-4775-bddb-74db27263e61/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",WXMI FOX 17 West Michigan
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D677785?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="578085" tvg-name="WXYZ Detroit 7 Action News" tvg-logo="https://canvas-lb.tubitv.com/opts/yG0WnzS_3bm65Q==/9b136cff-e70a-4a55-9cc4-30b318851cef/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",WXYZ Detroit 7 Action News
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D578085?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="680705" tvg-name="Wanted: Dead or Alive" tvg-logo="https://canvas-lb.tubitv.com/opts/cMalDW-Z-wT0Nw==/5583c936-6239-4da3-b733-a9aaeebbc2fe/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Wanted: Dead or Alive
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D680705?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000294" tvg-name="Watch AEW" tvg-logo="https://canvas-lb.tubitv.com/opts/yeAV3-c2XWfYzw==/e9cd4624-20d8-421b-b5ed-282769cf2f57/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Watch AEW
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000294?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000000" tvg-name="Waypoint TV" tvg-logo="https://canvas-lb.tubitv.com/opts/URb2SUqoOhNp3Q==/4b2bb660-9424-45c9-ad67-9c7099f60cbf/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Waypoint TV
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000000?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="715945" tvg-name="Welcome Home" tvg-logo="https://canvas-lb.tubitv.com/opts/DuU9Cn6o7BqCBg==/2f1fd1c5-7bdc-475f-841f-9a2a9f3ae75b/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Welcome Home
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D715945?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="670603" tvg-name="Wipeout Xtra" tvg-logo="https://canvas-lb.tubitv.com/opts/zpmicKsrwms87A==/991109c5-dce1-4eac-a23f-1d4713c52cbf/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Wipeout Xtra
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D670603?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="692073" tvg-name="Women's Sports Network" tvg-logo="https://canvas-lb.tubitv.com/opts/4d5Ea4ugACCJXg==/4a1d8a18-5086-438b-9298-7381aee4cb83/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Women's Sports Network
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D692073?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000293" tvg-name="World of Love Island" tvg-logo="https://canvas-lb.tubitv.com/opts/ONtAI886BGJLPQ==/f2b18c8c-c8c1-4a3c-97da-2a247fa7395e/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",World of Love Island
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000293?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="400000093" tvg-name="World's Most Evil Killers" tvg-logo="https://canvas-lb.tubitv.com/opts/qqJAXtXP7TIolA==/0aa317c5-3f1c-4949-9e48-3f257c8293c4/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",World's Most Evil Killers
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D400000093?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="702892" tvg-name="Xplore" tvg-logo="https://canvas-lb.tubitv.com/opts/O6w2cPsZ16GUNA==/075f8826-fdc1-4007-aed3-abe290b90ff7/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",Xplore
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D702892?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="613758" tvg-name="beIN Sports XTRA" tvg-logo="https://canvas-lb.tubitv.com/opts/ZznIonCFpZqA2g==/937ec9ac-b4bd-4c16-863b-75dc816129d7/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",beIN Sports XTRA
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D613758?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="613759" tvg-name="beIN Sports XTRA En Español" tvg-logo="https://canvas-lb.tubitv.com/opts/y4jAUpeHq4ELHg==/8968101d-cc65-48c7-a102-0a6a46ca55db/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",beIN Sports XTRA En Español
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D613759?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="555129" tvg-name="theGrio" tvg-logo="https://canvas-lb.tubitv.com/opts/TyT5UhcvEErw2A==/a9b7d587-ab4a-4d4d-bc0d-6f14da292f9f/CHgQeDoFMS4xLjlAAQ==" group-title="tubi",theGrio
+http://localhost:3000/api/ext/v1/tubi/https%3A%2F%2Ftubitv.com%2Foz%2Fepg%2Fprogramming%3Fcontent_id%3D555129?token=1f3e916c43f6abb9a0400f72350062ef&pl=tubi
+#EXTINF:-1 tvg-id="99951518" tvg-name="20/20" tvg-logo="https://image.xumo.com/v1/channels/channel/99951518/600x336.jpg?type=channelTile" group-title="xumo",20/20
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951518%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991659" tvg-name="25 Words or Less" tvg-logo="https://image.xumo.com/v1/channels/channel/99991659/600x336.jpg?type=channelTile" group-title="xumo",25 Words or Less
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991659%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951439" tvg-name="50 Cent Action" tvg-logo="https://image.xumo.com/v1/channels/channel/99951439/600x336.jpg?type=channelTile" group-title="xumo",50 Cent Action
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951439%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951482" tvg-name="@Home DIY" tvg-logo="https://image.xumo.com/v1/channels/channel/99951482/600x336.jpg?type=channelTile" group-title="xumo",@Home DIY
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951482%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951555" tvg-name="A&E Alaska State Troopers" tvg-logo="https://image.xumo.com/v1/channels/channel/99951555/600x336.jpg?type=channelTile" group-title="xumo",A&E Alaska State Troopers
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951555%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951471" tvg-name="A&E Crime 360" tvg-logo="https://image.xumo.com/v1/channels/channel/99951471/600x336.jpg?type=channelTile" group-title="xumo",A&E Crime 360
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951471%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951550" tvg-name="A&E Live PD: Greatest Shifts" tvg-logo="https://image.xumo.com/v1/channels/channel/99951550/600x336.jpg?type=channelTile" group-title="xumo",A&E Live PD: Greatest Shifts
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951550%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951517" tvg-name="ABC News Live" tvg-logo="https://image.xumo.com/v1/channels/channel/99951517/600x336.jpg?type=channelTile" group-title="xumo",ABC News Live
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951517%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991315" tvg-name="ACC Digital Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99991315/600x336.jpg?type=channelTile" group-title="xumo",ACC Digital Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991315%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951477" tvg-name="ALLBLK Gems" tvg-logo="https://image.xumo.com/v1/channels/channel/99951477/600x336.jpg?type=channelTile" group-title="xumo",ALLBLK Gems
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951477%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951377" tvg-name="AMC Thrillers" tvg-logo="https://image.xumo.com/v1/channels/channel/99951377/600x336.jpg?type=channelTile" group-title="xumo",AMC Thrillers
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951377%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951140" tvg-name="AMERICATEVÉ" tvg-logo="https://image.xumo.com/v1/channels/channel/99951140/600x336.jpg?type=channelTile" group-title="xumo",AMERICATEVÉ
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951140%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991649" tvg-name="AccuWeather NOW" tvg-logo="https://image.xumo.com/v1/channels/channel/99991649/600x336.jpg?type=channelTile" group-title="xumo",AccuWeather NOW
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991649%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951478" tvg-name="Acorn TV Mysteries" tvg-logo="https://image.xumo.com/v1/channels/channel/99951478/600x336.jpg?type=channelTile" group-title="xumo",Acorn TV Mysteries
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951478%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995110" tvg-name="Action News Jax" tvg-logo="https://image.xumo.com/v1/channels/channel/9995110/600x336.jpg?type=channelTile" group-title="xumo",Action News Jax
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995110%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951256" tvg-name="Alfred Hitchcock Presents" tvg-logo="https://image.xumo.com/v1/channels/channel/99951256/600x336.jpg?type=channelTile" group-title="xumo",Alfred Hitchcock Presents
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951256%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991292" tvg-name="Alien Nation by DUST" tvg-logo="https://image.xumo.com/v1/channels/channel/99991292/600x336.jpg?type=channelTile" group-title="xumo",Alien Nation by DUST
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991292%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991253" tvg-name="All Babies Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99991253/600x336.jpg?type=channelTile" group-title="xumo",All Babies Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991253%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951376" tvg-name="All Reality We TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951376/600x336.jpg?type=channelTile" group-title="xumo",All Reality We TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951376%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991625" tvg-name="All Weddings We TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991625/600x336.jpg?type=channelTile" group-title="xumo",All Weddings We TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991625%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951457" tvg-name="America's Got Talent" tvg-logo="https://image.xumo.com/v1/channels/channel/99951457/600x336.jpg?type=channelTile" group-title="xumo",America's Got Talent
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951457%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991369" tvg-name="America's Test Kitchen" tvg-logo="https://image.xumo.com/v1/channels/channel/99991369/600x336.jpg?type=channelTile" group-title="xumo",America's Test Kitchen
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991369%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951461" tvg-name="American Crimes" tvg-logo="https://image.xumo.com/v1/channels/channel/99951461/600x336.jpg?type=channelTile" group-title="xumo",American Crimes
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951461%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951318" tvg-name="American Ninja Warrior" tvg-logo="https://image.xumo.com/v1/channels/channel/99951318/600x336.jpg?type=channelTile" group-title="xumo",American Ninja Warrior
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951318%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951474" tvg-name="Ancient Aliens" tvg-logo="https://image.xumo.com/v1/channels/channel/99951474/600x336.jpg?type=channelTile" group-title="xumo",Ancient Aliens
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951474%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951192" tvg-name="Anger Management" tvg-logo="https://image.xumo.com/v1/channels/channel/99951192/600x336.jpg?type=channelTile" group-title="xumo",Anger Management
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951192%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951353" tvg-name="Antiques Road Trip" tvg-logo="https://image.xumo.com/v1/channels/channel/99951353/600x336.jpg?type=channelTile" group-title="xumo",Antiques Road Trip
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951353%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991667" tvg-name="Are We There Yet?" tvg-logo="https://image.xumo.com/v1/channels/channel/99991667/600x336.jpg?type=channelTile" group-title="xumo",Are We There Yet?
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991667%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951156" tvg-name="At Home with Family Handyman" tvg-logo="https://image.xumo.com/v1/channels/channel/99951156/600x336.jpg?type=channelTile" group-title="xumo",At Home with Family Handyman
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951156%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951497" tvg-name="BBC Drama" tvg-logo="https://image.xumo.com/v1/channels/channel/99951497/600x336.jpg?type=channelTile" group-title="xumo",BBC Drama
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951497%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951231" tvg-name="BBC Earth" tvg-logo="https://image.xumo.com/v1/channels/channel/99951231/600x336.jpg?type=channelTile" group-title="xumo",BBC Earth
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951231%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951177" tvg-name="BBC Food" tvg-logo="https://image.xumo.com/v1/channels/channel/99951177/600x336.jpg?type=channelTile" group-title="xumo",BBC Food
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951177%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951178" tvg-name="BBC Home & Garden" tvg-logo="https://image.xumo.com/v1/channels/channel/99951178/600x336.jpg?type=channelTile" group-title="xumo",BBC Home & Garden
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951178%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951298" tvg-name="BBC News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951298/600x336.jpg?type=channelTile" group-title="xumo",BBC News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951298%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951124" tvg-name="BUZZR" tvg-logo="https://image.xumo.com/v1/channels/channel/99951124/600x336.jpg?type=channelTile" group-title="xumo",BUZZR
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951124%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951209" tvg-name="Baby Shark TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951209/600x336.jpg?type=channelTile" group-title="xumo",Baby Shark TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951209%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951384" tvg-name="Bachelor Nation" tvg-logo="https://image.xumo.com/v1/channels/channel/99951384/600x336.jpg?type=channelTile" group-title="xumo",Bachelor Nation
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951384%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951467" tvg-name="Bad Girls Club" tvg-logo="https://image.xumo.com/v1/channels/channel/99951467/600x336.jpg?type=channelTile" group-title="xumo",Bad Girls Club
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951467%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951409" tvg-name="Bark TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951409/600x336.jpg?type=channelTile" group-title="xumo",Bark TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951409%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951133" tvg-name="Baywatch" tvg-logo="https://image.xumo.com/v1/channels/channel/99951133/600x336.jpg?type=channelTile" group-title="xumo",Baywatch
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951133%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951359" tvg-name="Big 12 Studios" tvg-logo="https://image.xumo.com/v1/channels/channel/99951359/600x336.jpg?type=channelTile" group-title="xumo",Big 12 Studios
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951359%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991627" tvg-name="Billiard TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991627/600x336.jpg?type=channelTile" group-title="xumo",Billiard TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991627%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951435" tvg-name="Bizaar" tvg-logo="https://image.xumo.com/v1/channels/channel/99951435/600x336.jpg?type=channelTile" group-title="xumo",Bizaar
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951435%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951393" tvg-name="Bizarre Foods with Andrew Zimmern" tvg-logo="https://image.xumo.com/v1/channels/channel/99951393/600x336.jpg?type=channelTile" group-title="xumo",Bizarre Foods with Andrew Zimmern
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951393%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951533" tvg-name="Bloomberg TV+" tvg-logo="https://image.xumo.com/v1/channels/channel/99951533/600x336.jpg?type=channelTile" group-title="xumo",Bloomberg TV+
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951533%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995108" tvg-name="Boston 25" tvg-logo="https://image.xumo.com/v1/channels/channel/9995108/600x336.jpg?type=channelTile" group-title="xumo",Boston 25
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995108%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9999613" tvg-name="Bounce XL" tvg-logo="https://image.xumo.com/v1/channels/channel/9999613/600x336.jpg?type=channelTile" group-title="xumo",Bounce XL
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9999613%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951510" tvg-name="Bowling TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951510/600x336.jpg?type=channelTile" group-title="xumo",Bowling TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951510%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951242" tvg-name="Bravo Vault" tvg-logo="https://image.xumo.com/v1/channels/channel/99951242/600x336.jpg?type=channelTile" group-title="xumo",Bravo Vault
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951242%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951213" tvg-name="BritBox Mysteries" tvg-logo="https://image.xumo.com/v1/channels/channel/99951213/600x336.jpg?type=channelTile" group-title="xumo",BritBox Mysteries
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951213%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991276" tvg-name="CBC News" tvg-logo="https://image.xumo.com/v1/channels/channel/99991276/600x336.jpg?type=channelTile" group-title="xumo",CBC News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991276%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991158" tvg-name="CBS News 24/7" tvg-logo="https://image.xumo.com/v1/channels/channel/99991158/600x336.jpg?type=channelTile" group-title="xumo",CBS News 24/7
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991158%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991655" tvg-name="CBS News Bay Area" tvg-logo="https://image.xumo.com/v1/channels/channel/99991655/600x336.jpg?type=channelTile" group-title="xumo",CBS News Bay Area
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991655%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991656" tvg-name="CBS News Boston" tvg-logo="https://image.xumo.com/v1/channels/channel/99991656/600x336.jpg?type=channelTile" group-title="xumo",CBS News Boston
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991656%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991643" tvg-name="CBS News Chicago" tvg-logo="https://image.xumo.com/v1/channels/channel/99991643/600x336.jpg?type=channelTile" group-title="xumo",CBS News Chicago
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991643%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991642" tvg-name="CBS News Los Angeles" tvg-logo="https://image.xumo.com/v1/channels/channel/99991642/600x336.jpg?type=channelTile" group-title="xumo",CBS News Los Angeles
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991642%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991641" tvg-name="CBS News New York" tvg-logo="https://image.xumo.com/v1/channels/channel/99991641/600x336.jpg?type=channelTile" group-title="xumo",CBS News New York
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991641%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991645" tvg-name="CBS Sports HQ" tvg-logo="https://image.xumo.com/v1/channels/channel/99991645/600x336.jpg?type=channelTile" group-title="xumo",CBS Sports HQ
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991645%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951386" tvg-name="CNN Headlines" tvg-logo="https://image.xumo.com/v1/channels/channel/99951386/600x336.jpg?type=channelTile" group-title="xumo",CNN Headlines
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951386%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951387" tvg-name="CNN Originals" tvg-logo="https://image.xumo.com/v1/channels/channel/99951387/600x336.jpg?type=channelTile" group-title="xumo",CNN Originals
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951387%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951367" tvg-name="Canela.TV Clasicos" tvg-logo="https://image.xumo.com/v1/channels/channel/99951367/600x336.jpg?type=channelTile" group-title="xumo",Canela.TV Clasicos
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951367%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991749" tvg-name="Caso Cerrado" tvg-logo="https://image.xumo.com/v1/channels/channel/99991749/600x336.jpg?type=channelTile" group-title="xumo",Caso Cerrado
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991749%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951252" tvg-name="Cheaters" tvg-logo="https://image.xumo.com/v1/channels/channel/99951252/600x336.jpg?type=channelTile" group-title="xumo",Cheaters
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951252%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991220" tvg-name="Cheddar News" tvg-logo="https://image.xumo.com/v1/channels/channel/99991220/600x336.jpg?type=channelTile" group-title="xumo",Cheddar News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991220%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991142" tvg-name="Cine Romántico" tvg-logo="https://image.xumo.com/v1/channels/channel/99991142/600x336.jpg?type=channelTile" group-title="xumo",Cine Romántico
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991142%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991131" tvg-name="Circle Country" tvg-logo="https://image.xumo.com/v1/channels/channel/99991131/600x336.jpg?type=channelTile" group-title="xumo",Circle Country
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991131%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951486" tvg-name="Classic Car Auctions by History" tvg-logo="https://image.xumo.com/v1/channels/channel/99951486/600x336.jpg?type=channelTile" group-title="xumo",Classic Car Auctions by History
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951486%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951248" tvg-name="Classic Doctor Who" tvg-logo="https://image.xumo.com/v1/channels/channel/99951248/600x336.jpg?type=channelTile" group-title="xumo",Classic Doctor Who
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951248%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991379" tvg-name="Combat War Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99991379/600x336.jpg?type=channelTile" group-title="xumo",Combat War Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991379%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951451" tvg-name="Come Dine With Me" tvg-logo="https://image.xumo.com/v1/channels/channel/99951451/600x336.jpg?type=channelTile" group-title="xumo",Come Dine With Me
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951451%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951463" tvg-name="Comedy Dynamics" tvg-logo="https://image.xumo.com/v1/channels/channel/99951463/600x336.jpg?type=channelTile" group-title="xumo",Comedy Dynamics
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951463%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951564" tvg-name="Como Dice El Dicho" tvg-logo="https://image.xumo.com/v1/channels/channel/99951564/600x336.jpg?type=channelTile" group-title="xumo",Como Dice El Dicho
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951564%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991303" tvg-name="Complex TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991303/600x336.jpg?type=channelTile" group-title="xumo",Complex TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991303%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991388" tvg-name="Confess by Nosey" tvg-logo="https://image.xumo.com/v1/channels/channel/99991388/600x336.jpg?type=channelTile" group-title="xumo",Confess by Nosey
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991388%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951323" tvg-name="Cook's Country" tvg-logo="https://image.xumo.com/v1/channels/channel/99951323/600x336.jpg?type=channelTile" group-title="xumo",Cook's Country
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951323%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951345" tvg-name="Cosmic Frontiers" tvg-logo="https://image.xumo.com/v1/channels/channel/99951345/600x336.jpg?type=channelTile" group-title="xumo",Cosmic Frontiers
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951345%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951559" tvg-name="Court TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951559/600x336.jpg?type=channelTile" group-title="xumo",Court TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951559%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951557" tvg-name="Cowboy+ Sports" tvg-logo="https://image.xumo.com/v1/channels/channel/99951557/600x336.jpg?type=channelTile" group-title="xumo",Cowboy+ Sports
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951557%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951210" tvg-name="CraftsyTV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951210/600x336.jpg?type=channelTile" group-title="xumo",CraftsyTV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951210%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951437" tvg-name="Creator TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951437/600x336.jpg?type=channelTile" group-title="xumo",Creator TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951437%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951358" tvg-name="Curiosity Now" tvg-logo="https://image.xumo.com/v1/channels/channel/99951358/600x336.jpg?type=channelTile" group-title="xumo",Curiosity Now
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951358%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991638" tvg-name="DOCUMENTARY+" tvg-logo="https://image.xumo.com/v1/channels/channel/99991638/600x336.jpg?type=channelTile" group-title="xumo",DOCUMENTARY+
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991638%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951488" tvg-name="Dance Moms by Lifetime" tvg-logo="https://image.xumo.com/v1/channels/channel/99951488/600x336.jpg?type=channelTile" group-title="xumo",Dance Moms by Lifetime
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951488%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9999615" tvg-name="Dark Matter TV" tvg-logo="https://image.xumo.com/v1/channels/channel/9999615/600x336.jpg?type=channelTile" group-title="xumo",Dark Matter TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9999615%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991626" tvg-name="Dateline 24/7" tvg-logo="https://image.xumo.com/v1/channels/channel/99991626/600x336.jpg?type=channelTile" group-title="xumo",Dateline 24/7
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991626%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991113" tvg-name="Deal Or No Deal" tvg-logo="https://image.xumo.com/v1/channels/channel/99991113/600x336.jpg?type=channelTile" group-title="xumo",Deal Or No Deal
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991113%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951553" tvg-name="Deal Zone by History" tvg-logo="https://image.xumo.com/v1/channels/channel/99951553/600x336.jpg?type=channelTile" group-title="xumo",Deal Zone by History
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951553%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951458" tvg-name="Declassified" tvg-logo="https://image.xumo.com/v1/channels/channel/99951458/600x336.jpg?type=channelTile" group-title="xumo",Declassified
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951458%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991381" tvg-name="Demand Africa" tvg-logo="https://image.xumo.com/v1/channels/channel/99991381/600x336.jpg?type=channelTile" group-title="xumo",Demand Africa
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991381%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951346" tvg-name="Designated Survivor" tvg-logo="https://image.xumo.com/v1/channels/channel/99951346/600x336.jpg?type=channelTile" group-title="xumo",Designated Survivor
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951346%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951438" tvg-name="Discovery Turbo TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951438/600x336.jpg?type=channelTile" group-title="xumo",Discovery Turbo TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951438%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991346" tvg-name="Divorce Court" tvg-logo="https://image.xumo.com/v1/channels/channel/99991346/600x336.jpg?type=channelTile" group-title="xumo",Divorce Court
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991346%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951294" tvg-name="Dog Whisperer" tvg-logo="https://image.xumo.com/v1/channels/channel/99951294/600x336.jpg?type=channelTile" group-title="xumo",Dog Whisperer
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951294%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951485" tvg-name="Dog the Bounty Hunter" tvg-logo="https://image.xumo.com/v1/channels/channel/99951485/600x336.jpg?type=channelTile" group-title="xumo",Dog the Bounty Hunter
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951485%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991333" tvg-name="Dove Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99991333/600x336.jpg?type=channelTile" group-title="xumo",Dove Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991333%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951370" tvg-name="Dr. Phil" tvg-logo="https://image.xumo.com/v1/channels/channel/99951370/600x336.jpg?type=channelTile" group-title="xumo",Dr. Phil
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951370%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951440" tvg-name="Dungeons & Dragons Adventures" tvg-logo="https://image.xumo.com/v1/channels/channel/99951440/600x336.jpg?type=channelTile" group-title="xumo",Dungeons & Dragons Adventures
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951440%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951465" tvg-name="E! Keeping Up" tvg-logo="https://image.xumo.com/v1/channels/channel/99951465/600x336.jpg?type=channelTile" group-title="xumo",E! Keeping Up
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951465%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991670" tvg-name="ET" tvg-logo="https://image.xumo.com/v1/channels/channel/99991670/600x336.jpg?type=channelTile" group-title="xumo",ET
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991670%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951378" tvg-name="EarthXtra" tvg-logo="https://image.xumo.com/v1/channels/channel/99951378/600x336.jpg?type=channelTile" group-title="xumo",EarthXtra
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951378%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951293" tvg-name="Ebony TV by Lionsgate" tvg-logo="https://image.xumo.com/v1/channels/channel/99951293/600x336.jpg?type=channelTile" group-title="xumo",Ebony TV by Lionsgate
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951293%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951536" tvg-name="El Rey Rebel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951536/600x336.jpg?type=channelTile" group-title="xumo",El Rey Rebel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951536%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991378" tvg-name="ElectricNOW" tvg-logo="https://image.xumo.com/v1/channels/channel/99991378/600x336.jpg?type=channelTile" group-title="xumo",ElectricNOW
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991378%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951543" tvg-name="Elevation Church Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99951543/600x336.jpg?type=channelTile" group-title="xumo",Elevation Church Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951543%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991776" tvg-name="Estrella News" tvg-logo="https://image.xumo.com/v1/channels/channel/99991776/600x336.jpg?type=channelTile" group-title="xumo",Estrella News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991776%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991746" tvg-name="EstrellaTV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991746/600x336.jpg?type=channelTile" group-title="xumo",EstrellaTV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991746%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951432" tvg-name="Extreme Jobs" tvg-logo="https://image.xumo.com/v1/channels/channel/99951432/600x336.jpg?type=channelTile" group-title="xumo",Extreme Jobs
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951432%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951189" tvg-name="FAITHOPE" tvg-logo="https://image.xumo.com/v1/channels/channel/99951189/600x336.jpg?type=channelTile" group-title="xumo",FAITHOPE
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951189%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951120" tvg-name="FILMEX" tvg-logo="https://image.xumo.com/v1/channels/channel/99951120/600x336.jpg?type=channelTile" group-title="xumo",FILMEX
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951120%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99981121" tvg-name="FILMEX CLASICO" tvg-logo="https://image.xumo.com/v1/channels/channel/99981121/600x336.jpg?type=channelTile" group-title="xumo",FILMEX CLASICO
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99981121%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951426" tvg-name="FOX LOCAL Atlanta" tvg-logo="https://image.xumo.com/v1/channels/channel/99951426/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Atlanta
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951426%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951430" tvg-name="FOX LOCAL Austin" tvg-logo="https://image.xumo.com/v1/channels/channel/99951430/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Austin
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951430%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951415" tvg-name="FOX LOCAL Chicago" tvg-logo="https://image.xumo.com/v1/channels/channel/99951415/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Chicago
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951415%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951418" tvg-name="FOX LOCAL Dallas-Fort Worth" tvg-logo="https://image.xumo.com/v1/channels/channel/99951418/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Dallas-Fort Worth
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951418%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951421" tvg-name="FOX LOCAL Detroit" tvg-logo="https://image.xumo.com/v1/channels/channel/99951421/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Detroit
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951421%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951423" tvg-name="FOX LOCAL Houston" tvg-logo="https://image.xumo.com/v1/channels/channel/99951423/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Houston
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951423%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951420" tvg-name="FOX LOCAL Los Angeles" tvg-logo="https://image.xumo.com/v1/channels/channel/99951420/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Los Angeles
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951420%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951429" tvg-name="FOX LOCAL Milwaukee" tvg-logo="https://image.xumo.com/v1/channels/channel/99951429/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Milwaukee
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951429%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951431" tvg-name="FOX LOCAL Minnesota" tvg-logo="https://image.xumo.com/v1/channels/channel/99951431/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Minnesota
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951431%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951427" tvg-name="FOX LOCAL New York" tvg-logo="https://image.xumo.com/v1/channels/channel/99951427/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL New York
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951427%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951425" tvg-name="FOX LOCAL Orlando" tvg-logo="https://image.xumo.com/v1/channels/channel/99951425/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Orlando
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951425%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951424" tvg-name="FOX LOCAL Philadelphia" tvg-logo="https://image.xumo.com/v1/channels/channel/99951424/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Philadelphia
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951424%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951419" tvg-name="FOX LOCAL Phoenix" tvg-logo="https://image.xumo.com/v1/channels/channel/99951419/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Phoenix
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951419%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951422" tvg-name="FOX LOCAL San Francisco" tvg-logo="https://image.xumo.com/v1/channels/channel/99951422/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL San Francisco
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951422%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951417" tvg-name="FOX LOCAL Seattle" tvg-logo="https://image.xumo.com/v1/channels/channel/99951417/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Seattle
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951417%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951416" tvg-name="FOX LOCAL Tampa Bay" tvg-logo="https://image.xumo.com/v1/channels/channel/99951416/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Tampa Bay
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951416%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951428" tvg-name="FOX LOCAL Washington DC" tvg-logo="https://image.xumo.com/v1/channels/channel/99951428/600x336.jpg?type=channelTile" group-title="xumo",FOX LOCAL Washington DC
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951428%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991196" tvg-name="FOX Sports" tvg-logo="https://image.xumo.com/v1/channels/channel/99991196/600x336.jpg?type=channelTile" group-title="xumo",FOX Sports
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991196%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991153" tvg-name="FailArmy" tvg-logo="https://image.xumo.com/v1/channels/channel/99991153/600x336.jpg?type=channelTile" group-title="xumo",FailArmy
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991153%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951146" tvg-name="Family Affair Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951146/600x336.jpg?type=channelTile" group-title="xumo",Family Affair Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951146%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991232" tvg-name="Family Feud" tvg-logo="https://image.xumo.com/v1/channels/channel/99991232/600x336.jpg?type=channelTile" group-title="xumo",Family Feud
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991232%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951339" tvg-name="Family Feud Classic" tvg-logo="https://image.xumo.com/v1/channels/channel/99951339/600x336.jpg?type=channelTile" group-title="xumo",Family Feud Classic
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951339%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951266" tvg-name="FanDuel TV Extra" tvg-logo="https://image.xumo.com/v1/channels/channel/99951266/600x336.jpg?type=channelTile" group-title="xumo",FanDuel TV Extra
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951266%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951130" tvg-name="Fear Factor" tvg-logo="https://image.xumo.com/v1/channels/channel/99951130/600x336.jpg?type=channelTile" group-title="xumo",Fear Factor
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951130%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991374" tvg-name="Field & Stream TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991374/600x336.jpg?type=channelTile" group-title="xumo",Field & Stream TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991374%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951207" tvg-name="Fifth Gear" tvg-logo="https://image.xumo.com/v1/channels/channel/99951207/600x336.jpg?type=channelTile" group-title="xumo",Fifth Gear
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951207%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991337" tvg-name="FilmRise" tvg-logo="https://image.xumo.com/v1/channels/channel/99991337/600x336.jpg?type=channelTile" group-title="xumo",FilmRise
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991337%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951287" tvg-name="Fluffy TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951287/600x336.jpg?type=channelTile" group-title="xumo",Fluffy TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951287%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991367" tvg-name="Forensic Files" tvg-logo="https://image.xumo.com/v1/channels/channel/99991367/600x336.jpg?type=channelTile" group-title="xumo",Forensic Files
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991367%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991694" tvg-name="Fox Weather" tvg-logo="https://image.xumo.com/v1/channels/channel/99991694/600x336.jpg?type=channelTile" group-title="xumo",Fox Weather
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991694%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951548" tvg-name="Fubo Sports Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99951548/600x336.jpg?type=channelTile" group-title="xumo",Fubo Sports Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951548%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991278" tvg-name="GLORY Kickboxing" tvg-logo="https://image.xumo.com/v1/channels/channel/99991278/600x336.jpg?type=channelTile" group-title="xumo",GLORY Kickboxing
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991278%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951462" tvg-name="GOLFPASS" tvg-logo="https://image.xumo.com/v1/channels/channel/99951462/600x336.jpg?type=channelTile" group-title="xumo",GOLFPASS
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951462%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951524" tvg-name="GaitherTV FAST" tvg-logo="https://image.xumo.com/v1/channels/channel/99951524/600x336.jpg?type=channelTile" group-title="xumo",GaitherTV FAST
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951524%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951212" tvg-name="Garden with Monty Don" tvg-logo="https://image.xumo.com/v1/channels/channel/99951212/600x336.jpg?type=channelTile" group-title="xumo",Garden with Monty Don
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951212%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951277" tvg-name="Ghost Hunters" tvg-logo="https://image.xumo.com/v1/channels/channel/99951277/600x336.jpg?type=channelTile" group-title="xumo",Ghost Hunters
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951277%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951391" tvg-name="Ghosts Are Real" tvg-logo="https://image.xumo.com/v1/channels/channel/99951391/600x336.jpg?type=channelTile" group-title="xumo",Ghosts Are Real
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951391%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951493" tvg-name="GoldenTV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951493/600x336.jpg?type=channelTile" group-title="xumo",GoldenTV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951493%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991312" tvg-name="Gravitas Movies" tvg-logo="https://image.xumo.com/v1/channels/channel/99991312/600x336.jpg?type=channelTile" group-title="xumo",Gravitas Movies
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991312%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951515" tvg-name="Great British Menu" tvg-logo="https://image.xumo.com/v1/channels/channel/99951515/600x336.jpg?type=channelTile" group-title="xumo",Great British Menu
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951515%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951152" tvg-name="Grit Xtra" tvg-logo="https://image.xumo.com/v1/channels/channel/99951152/600x336.jpg?type=channelTile" group-title="xumo",Grit Xtra
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951152%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951480" tvg-name="Growing Up Hip-Hop" tvg-logo="https://image.xumo.com/v1/channels/channel/99951480/600x336.jpg?type=channelTile" group-title="xumo",Growing Up Hip-Hop
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951480%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991328" tvg-name="GustoTV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991328/600x336.jpg?type=channelTile" group-title="xumo",GustoTV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991328%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951469" tvg-name="HBO Boxing" tvg-logo="https://image.xumo.com/v1/channels/channel/99951469/600x336.jpg?type=channelTile" group-title="xumo",HBO Boxing
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951469%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991271" tvg-name="HSN" tvg-logo="https://image.xumo.com/v1/channels/channel/99991271/600x336.jpg?type=channelTile" group-title="xumo",HSN
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991271%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991709" tvg-name="Hallmark Movies & More" tvg-logo="https://image.xumo.com/v1/channels/channel/99991709/600x336.jpg?type=channelTile" group-title="xumo",Hallmark Movies & More
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991709%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951375" tvg-name="Haunt TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951375/600x336.jpg?type=channelTile" group-title="xumo",Haunt TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951375%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951494" tvg-name="Heartland" tvg-logo="https://image.xumo.com/v1/channels/channel/99951494/600x336.jpg?type=channelTile" group-title="xumo",Heartland
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951494%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991681" tvg-name="Hell's Kitchen" tvg-logo="https://image.xumo.com/v1/channels/channel/99991681/600x336.jpg?type=channelTile" group-title="xumo",Hell's Kitchen
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991681%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991302" tvg-name="Hi-Yah!" tvg-logo="https://image.xumo.com/v1/channels/channel/99991302/600x336.jpg?type=channelTile" group-title="xumo",Hi-Yah!
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991302%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951509" tvg-name="Highway Thru Hell" tvg-logo="https://image.xumo.com/v1/channels/channel/99951509/600x336.jpg?type=channelTile" group-title="xumo",Highway Thru Hell
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951509%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951401" tvg-name="Highway to Heaven" tvg-logo="https://image.xumo.com/v1/channels/channel/99951401/600x336.jpg?type=channelTile" group-title="xumo",Highway to Heaven
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951401%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951397" tvg-name="Hit Sitcoms" tvg-logo="https://image.xumo.com/v1/channels/channel/99951397/600x336.jpg?type=channelTile" group-title="xumo",Hit Sitcoms
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951397%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951470" tvg-name="Home. Made. Nation" tvg-logo="https://image.xumo.com/v1/channels/channel/99951470/600x336.jpg?type=channelTile" group-title="xumo",Home. Made. Nation
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951470%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991693" tvg-name="Homeful" tvg-logo="https://image.xumo.com/v1/channels/channel/99991693/600x336.jpg?type=channelTile" group-title="xumo",Homeful
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991693%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951392" tvg-name="How-To" tvg-logo="https://image.xumo.com/v1/channels/channel/99951392/600x336.jpg?type=channelTile" group-title="xumo",How-To
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951392%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991380" tvg-name="Hungry" tvg-logo="https://image.xumo.com/v1/channels/channel/99991380/600x336.jpg?type=channelTile" group-title="xumo",Hungry
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991380%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951158" tvg-name="ION" tvg-logo="https://image.xumo.com/v1/channels/channel/99951158/600x336.jpg?type=channelTile" group-title="xumo",ION
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951158%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951157" tvg-name="ION Mystery" tvg-logo="https://image.xumo.com/v1/channels/channel/99951157/600x336.jpg?type=channelTile" group-title="xumo",ION Mystery
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951157%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9999614" tvg-name="ION Plus" tvg-logo="https://image.xumo.com/v1/channels/channel/9999614/600x336.jpg?type=channelTile" group-title="xumo",ION Plus
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9999614%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951484" tvg-name="Ice Road Truckers by History" tvg-logo="https://image.xumo.com/v1/channels/channel/99951484/600x336.jpg?type=channelTile" group-title="xumo",Ice Road Truckers by History
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951484%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951434" tvg-name="Impact Gospel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951434/600x336.jpg?type=channelTile" group-title="xumo",Impact Gospel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951434%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951481" tvg-name="In Touch + Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99951481/600x336.jpg?type=channelTile" group-title="xumo",In Touch + Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951481%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991349" tvg-name="It's Showtime at the Apollo" tvg-logo="https://image.xumo.com/v1/channels/channel/99991349/600x336.jpg?type=channelTile" group-title="xumo",It's Showtime at the Apollo
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991349%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991338" tvg-name="JTV Jewelry Love" tvg-logo="https://image.xumo.com/v1/channels/channel/99991338/600x336.jpg?type=channelTile" group-title="xumo",JTV Jewelry Love
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991338%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951565" tvg-name="Jajaja" tvg-logo="https://image.xumo.com/v1/channels/channel/99951565/600x336.jpg?type=channelTile" group-title="xumo",Jajaja
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951565%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951141" tvg-name="Jewish Life TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951141/600x336.jpg?type=channelTile" group-title="xumo",Jewish Life TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951141%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951344" tvg-name="Joel Osteen Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99951344/600x336.jpg?type=channelTile" group-title="xumo",Joel Osteen Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951344%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991157" tvg-name="Johnny Carson TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991157/600x336.jpg?type=channelTile" group-title="xumo",Johnny Carson TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991157%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991176" tvg-name="Just for Laughs Comedy" tvg-logo="https://image.xumo.com/v1/channels/channel/99991176/600x336.jpg?type=channelTile" group-title="xumo",Just for Laughs Comedy
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991176%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991204" tvg-name="Just for Laughs Gags" tvg-logo="https://image.xumo.com/v1/channels/channel/99991204/600x336.jpg?type=channelTile" group-title="xumo",Just for Laughs Gags
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991204%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995112" tvg-name="KIRO Seattle" tvg-logo="https://image.xumo.com/v1/channels/channel/9995112/600x336.jpg?type=channelTile" group-title="xumo",KIRO Seattle
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995112%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991348" tvg-name="KOCOWA K-Drama" tvg-logo="https://image.xumo.com/v1/channels/channel/99991348/600x336.jpg?type=channelTile" group-title="xumo",KOCOWA K-Drama
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991348%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951492" tvg-name="LOL Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99951492/600x336.jpg?type=channelTile" group-title="xumo",LOL Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951492%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951449" tvg-name="LUCHA PLUS" tvg-logo="https://image.xumo.com/v1/channels/channel/99951449/600x336.jpg?type=channelTile" group-title="xumo",LUCHA PLUS
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951449%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951568" tvg-name="La Fea Más Bella" tvg-logo="https://image.xumo.com/v1/channels/channel/99951568/600x336.jpg?type=channelTile" group-title="xumo",La Fea Más Bella
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951568%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951232" tvg-name="Laff More" tvg-logo="https://image.xumo.com/v1/channels/channel/99951232/600x336.jpg?type=channelTile" group-title="xumo",Laff More
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951232%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951238" tvg-name="Las Vegas" tvg-logo="https://image.xumo.com/v1/channels/channel/99951238/600x336.jpg?type=channelTile" group-title="xumo",Las Vegas
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951238%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951259" tvg-name="Lassie" tvg-logo="https://image.xumo.com/v1/channels/channel/99951259/600x336.jpg?type=channelTile" group-title="xumo",Lassie
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951259%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951468" tvg-name="Law & Order" tvg-logo="https://image.xumo.com/v1/channels/channel/99951468/600x336.jpg?type=channelTile" group-title="xumo",Law & Order
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951468%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991320" tvg-name="Law&Crime" tvg-logo="https://image.xumo.com/v1/channels/channel/99991320/600x336.jpg?type=channelTile" group-title="xumo",Law&Crime
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991320%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951410" tvg-name="Lawless by Lionsgate" tvg-logo="https://image.xumo.com/v1/channels/channel/99951410/600x336.jpg?type=channelTile" group-title="xumo",Lawless by Lionsgate
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951410%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951257" tvg-name="Leave It to Beaver" tvg-logo="https://image.xumo.com/v1/channels/channel/99951257/600x336.jpg?type=channelTile" group-title="xumo",Leave It to Beaver
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951257%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951151" tvg-name="Lidia's Kitchen" tvg-logo="https://image.xumo.com/v1/channels/channel/99951151/600x336.jpg?type=channelTile" group-title="xumo",Lidia's Kitchen
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951151%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951240" tvg-name="Little House on the Prairie" tvg-logo="https://image.xumo.com/v1/channels/channel/99951240/600x336.jpg?type=channelTile" group-title="xumo",Little House on the Prairie
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951240%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951489" tvg-name="Live PD Presents" tvg-logo="https://image.xumo.com/v1/channels/channel/99951489/600x336.jpg?type=channelTile" group-title="xumo",Live PD Presents
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951489%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991635" tvg-name="LiveNOW from FOX" tvg-logo="https://image.xumo.com/v1/channels/channel/99991635/600x336.jpg?type=channelTile" group-title="xumo",LiveNOW from FOX
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991635%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991282" tvg-name="Local Now" tvg-logo="https://image.xumo.com/v1/channels/channel/99991282/600x336.jpg?type=channelTile" group-title="xumo",Local Now
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991282%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951479" tvg-name="Love After Lockup We TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951479/600x336.jpg?type=channelTile" group-title="xumo",Love After Lockup We TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951479%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991398" tvg-name="Love Nature" tvg-logo="https://image.xumo.com/v1/channels/channel/99991398/600x336.jpg?type=channelTile" group-title="xumo",Love Nature
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991398%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951328" tvg-name="Love The Planet" tvg-logo="https://image.xumo.com/v1/channels/channel/99951328/600x336.jpg?type=channelTile" group-title="xumo",Love The Planet
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951328%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951444" tvg-name="Lucky Dog" tvg-logo="https://image.xumo.com/v1/channels/channel/99951444/600x336.jpg?type=channelTile" group-title="xumo",Lucky Dog
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951444%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991399" tvg-name="Magnolia Selects" tvg-logo="https://image.xumo.com/v1/channels/channel/99991399/600x336.jpg?type=channelTile" group-title="xumo",Magnolia Selects
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991399%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951487" tvg-name="Matched Married Meet by Lifetime" tvg-logo="https://image.xumo.com/v1/channels/channel/99951487/600x336.jpg?type=channelTile" group-title="xumo",Matched Married Meet by Lifetime
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951487%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991336" tvg-name="Maverick Black Cinema" tvg-logo="https://image.xumo.com/v1/channels/channel/99991336/600x336.jpg?type=channelTile" group-title="xumo",Maverick Black Cinema
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991336%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951262" tvg-name="Mayday: Air Disaster" tvg-logo="https://image.xumo.com/v1/channels/channel/99951262/600x336.jpg?type=channelTile" group-title="xumo",Mayday: Air Disaster
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951262%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951138" tvg-name="McLeod's Daughters" tvg-logo="https://image.xumo.com/v1/channels/channel/99951138/600x336.jpg?type=channelTile" group-title="xumo",McLeod's Daughters
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951138%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991698" tvg-name="Midsomer Murders" tvg-logo="https://image.xumo.com/v1/channels/channel/99991698/600x336.jpg?type=channelTile" group-title="xumo",Midsomer Murders
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991698%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951237" tvg-name="Million Dollar Listing Vault" tvg-logo="https://image.xumo.com/v1/channels/channel/99951237/600x336.jpg?type=channelTile" group-title="xumo",Million Dollar Listing Vault
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951237%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951473" tvg-name="Modern Marvels by History" tvg-logo="https://image.xumo.com/v1/channels/channel/99951473/600x336.jpg?type=channelTile" group-title="xumo",Modern Marvels by History
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951473%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991325" tvg-name="Motorvision" tvg-logo="https://image.xumo.com/v1/channels/channel/99991325/600x336.jpg?type=channelTile" group-title="xumo",Motorvision
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991325%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951251" tvg-name="MovieSphere by Lionsgate" tvg-logo="https://image.xumo.com/v1/channels/channel/99951251/600x336.jpg?type=channelTile" group-title="xumo",MovieSphere by Lionsgate
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951251%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951239" tvg-name="Murder, She Wrote" tvg-logo="https://image.xumo.com/v1/channels/channel/99951239/600x336.jpg?type=channelTile" group-title="xumo",Murder, She Wrote
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951239%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951452" tvg-name="Murdoch Mysteries" tvg-logo="https://image.xumo.com/v1/channels/channel/99951452/600x336.jpg?type=channelTile" group-title="xumo",Murdoch Mysteries
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951452%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951442" tvg-name="My Little Pony" tvg-logo="https://image.xumo.com/v1/channels/channel/99951442/600x336.jpg?type=channelTile" group-title="xumo",My Little Pony
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951442%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951398" tvg-name="Mysterious Worlds" tvg-logo="https://image.xumo.com/v1/channels/channel/99951398/600x336.jpg?type=channelTile" group-title="xumo",Mysterious Worlds
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951398%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991616" tvg-name="Mystery Science Theater 3000 (MST3K)" tvg-logo="https://image.xumo.com/v1/channels/channel/99991616/600x336.jpg?type=channelTile" group-title="xumo",Mystery Science Theater 3000 (MST3K)
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991616%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951396" tvg-name="MythBusters" tvg-logo="https://image.xumo.com/v1/channels/channel/99951396/600x336.jpg?type=channelTile" group-title="xumo",MythBusters
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951396%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951413" tvg-name="NASCAR Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951413/600x336.jpg?type=channelTile" group-title="xumo",NASCAR Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951413%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951168" tvg-name="NBC 10 Boston News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951168/600x336.jpg?type=channelTile" group-title="xumo",NBC 10 Boston News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951168%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951166" tvg-name="NBC 10 Philadelphia News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951166/600x336.jpg?type=channelTile" group-title="xumo",NBC 10 Philadelphia News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951166%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951164" tvg-name="NBC 4 Los Angeles News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951164/600x336.jpg?type=channelTile" group-title="xumo",NBC 4 Los Angeles News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951164%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951163" tvg-name="NBC 4 New York News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951163/600x336.jpg?type=channelTile" group-title="xumo",NBC 4 New York News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951163%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951181" tvg-name="NBC 4 Washington News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951181/600x336.jpg?type=channelTile" group-title="xumo",NBC 4 Washington News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951181%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951165" tvg-name="NBC 5 Chicago News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951165/600x336.jpg?type=channelTile" group-title="xumo",NBC 5 Chicago News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951165%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951182" tvg-name="NBC 5 Dallas-Fort Worth News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951182/600x336.jpg?type=channelTile" group-title="xumo",NBC 5 Dallas-Fort Worth News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951182%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951167" tvg-name="NBC 6 South Florida News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951167/600x336.jpg?type=channelTile" group-title="xumo",NBC 6 South Florida News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951167%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951185" tvg-name="NBC 7 San Diego News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951185/600x336.jpg?type=channelTile" group-title="xumo",NBC 7 San Diego News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951185%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951162" tvg-name="NBC Bay Area News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951162/600x336.jpg?type=channelTile" group-title="xumo",NBC Bay Area News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951162%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951244" tvg-name="NBC Comedy Vault" tvg-logo="https://image.xumo.com/v1/channels/channel/99951244/600x336.jpg?type=channelTile" group-title="xumo",NBC Comedy Vault
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951244%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951183" tvg-name="NBC Connecticut News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951183/600x336.jpg?type=channelTile" group-title="xumo",NBC Connecticut News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951183%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991651" tvg-name="NBC LX Home" tvg-logo="https://image.xumo.com/v1/channels/channel/99991651/600x336.jpg?type=channelTile" group-title="xumo",NBC LX Home
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991651%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991247" tvg-name="NBC News NOW" tvg-logo="https://image.xumo.com/v1/channels/channel/99991247/600x336.jpg?type=channelTile" group-title="xumo",NBC News NOW
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991247%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951253" tvg-name="NBC Sports NOW" tvg-logo="https://image.xumo.com/v1/channels/channel/99951253/600x336.jpg?type=channelTile" group-title="xumo",NBC Sports NOW
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951253%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991386" tvg-name="NEW Korean MOVIES & SERIES" tvg-logo="https://image.xumo.com/v1/channels/channel/99991386/600x336.jpg?type=channelTile" group-title="xumo",NEW Korean MOVIES & SERIES
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991386%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991738" tvg-name="NFL Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99991738/600x336.jpg?type=channelTile" group-title="xumo",NFL Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991738%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951330" tvg-name="Nash Bridges" tvg-logo="https://image.xumo.com/v1/channels/channel/99951330/600x336.jpg?type=channelTile" group-title="xumo",Nash Bridges
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951330%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991197" tvg-name="NatureVision" tvg-logo="https://image.xumo.com/v1/channels/channel/99991197/600x336.jpg?type=channelTile" group-title="xumo",NatureVision
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991197%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951222" tvg-name="News 12 New York" tvg-logo="https://image.xumo.com/v1/channels/channel/99951222/600x336.jpg?type=channelTile" group-title="xumo",News 12 New York
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951222%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991194" tvg-name="Newsmax2" tvg-logo="https://image.xumo.com/v1/channels/channel/99991194/600x336.jpg?type=channelTile" group-title="xumo",Newsmax2
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991194%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951229" tvg-name="Ninja Kidz TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951229/600x336.jpg?type=channelTile" group-title="xumo",Ninja Kidz TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951229%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991366" tvg-name="Nosey" tvg-logo="https://image.xumo.com/v1/channels/channel/99991366/600x336.jpg?type=channelTile" group-title="xumo",Nosey
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991366%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951321" tvg-name="Noticias Telemundo Ahora" tvg-logo="https://image.xumo.com/v1/channels/channel/99951321/600x336.jpg?type=channelTile" group-title="xumo",Noticias Telemundo Ahora
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951321%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951562" tvg-name="Noticias Univision 24/7" tvg-logo="https://image.xumo.com/v1/channels/channel/99951562/600x336.jpg?type=channelTile" group-title="xumo",Noticias Univision 24/7
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951562%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951404" tvg-name="OAN Plus" tvg-logo="https://image.xumo.com/v1/channels/channel/99951404/600x336.jpg?type=channelTile" group-title="xumo",OAN Plus
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951404%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951530" tvg-name="ONE Championship" tvg-logo="https://image.xumo.com/v1/channels/channel/99951530/600x336.jpg?type=channelTile" group-title="xumo",ONE Championship
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951530%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951288" tvg-name="OUTflix Movies" tvg-logo="https://image.xumo.com/v1/channels/channel/99951288/600x336.jpg?type=channelTile" group-title="xumo",OUTflix Movies
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951288%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951250" tvg-name="OuterSphere by Lionsgate" tvg-logo="https://image.xumo.com/v1/channels/channel/99951250/600x336.jpg?type=channelTile" group-title="xumo",OuterSphere by Lionsgate
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951250%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951466" tvg-name="Oxygen True Crime Archives" tvg-logo="https://image.xumo.com/v1/channels/channel/99951466/600x336.jpg?type=channelTile" group-title="xumo",Oxygen True Crime Archives
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951466%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951388" tvg-name="PBR RidePass" tvg-logo="https://image.xumo.com/v1/channels/channel/99951388/600x336.jpg?type=channelTile" group-title="xumo",PBR RidePass
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951388%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951206" tvg-name="PBS Antiques Roadshow" tvg-logo="https://image.xumo.com/v1/channels/channel/99951206/600x336.jpg?type=channelTile" group-title="xumo",PBS Antiques Roadshow
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951206%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951195" tvg-name="PBS Nature" tvg-logo="https://image.xumo.com/v1/channels/channel/99951195/600x336.jpg?type=channelTile" group-title="xumo",PBS Nature
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951195%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951203" tvg-name="PFL MMA" tvg-logo="https://image.xumo.com/v1/channels/channel/99951203/600x336.jpg?type=channelTile" group-title="xumo",PFL MMA
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951203%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991281" tvg-name="PGA TOUR" tvg-logo="https://image.xumo.com/v1/channels/channel/99991281/600x336.jpg?type=channelTile" group-title="xumo",PGA TOUR
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991281%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991769" tvg-name="Paranormal Files" tvg-logo="https://image.xumo.com/v1/channels/channel/99991769/600x336.jpg?type=channelTile" group-title="xumo",Paranormal Files
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991769%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951390" tvg-name="PickleballTV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951390/600x336.jpg?type=channelTile" group-title="xumo",PickleballTV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951390%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951350" tvg-name="Places & Spaces" tvg-logo="https://image.xumo.com/v1/channels/channel/99951350/600x336.jpg?type=channelTile" group-title="xumo",Places & Spaces
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951350%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991633" tvg-name="PokerGO" tvg-logo="https://image.xumo.com/v1/channels/channel/99991633/600x336.jpg?type=channelTile" group-title="xumo",PokerGO
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991633%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951301" tvg-name="Portlandia" tvg-logo="https://image.xumo.com/v1/channels/channel/99951301/600x336.jpg?type=channelTile" group-title="xumo",Portlandia
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951301%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951441" tvg-name="Power Rangers" tvg-logo="https://image.xumo.com/v1/channels/channel/99951441/600x336.jpg?type=channelTile" group-title="xumo",Power Rangers
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951441%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991291" tvg-name="PowerNation" tvg-logo="https://image.xumo.com/v1/channels/channel/99991291/600x336.jpg?type=channelTile" group-title="xumo",PowerNation
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991291%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951221" tvg-name="Property & Reno" tvg-logo="https://image.xumo.com/v1/channels/channel/99951221/600x336.jpg?type=channelTile" group-title="xumo",Property & Reno
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951221%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951537" tvg-name="Property Brothers" tvg-logo="https://image.xumo.com/v1/channels/channel/99951537/600x336.jpg?type=channelTile" group-title="xumo",Property Brothers
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951537%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951407" tvg-name="Pure Flix TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951407/600x336.jpg?type=channelTile" group-title="xumo",Pure Flix TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951407%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991648" tvg-name="PursuitUp" tvg-logo="https://image.xumo.com/v1/channels/channel/99991648/600x336.jpg?type=channelTile" group-title="xumo",PursuitUp
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991648%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991344" tvg-name="QVC" tvg-logo="https://image.xumo.com/v1/channels/channel/99991344/600x336.jpg?type=channelTile" group-title="xumo",QVC
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991344%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951405" tvg-name="QVC2" tvg-logo="https://image.xumo.com/v1/channels/channel/99951405/600x336.jpg?type=channelTile" group-title="xumo",QVC2
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951405%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951269" tvg-name="RACER Select" tvg-logo="https://image.xumo.com/v1/channels/channel/99951269/600x336.jpg?type=channelTile" group-title="xumo",RACER Select
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951269%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991368" tvg-name="REELZ Famous & Infamous" tvg-logo="https://image.xumo.com/v1/channels/channel/99991368/600x336.jpg?type=channelTile" group-title="xumo",REELZ Famous & Infamous
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991368%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991283" tvg-name="Rainbow Rangers" tvg-logo="https://image.xumo.com/v1/channels/channel/99991283/600x336.jpg?type=channelTile" group-title="xumo",Rainbow Rangers
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991283%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951243" tvg-name="Real Housewives Vault" tvg-logo="https://image.xumo.com/v1/channels/channel/99951243/600x336.jpg?type=channelTile" group-title="xumo",Real Housewives Vault
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951243%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951381" tvg-name="Real Madrid TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951381/600x336.jpg?type=channelTile" group-title="xumo",Real Madrid TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951381%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951567" tvg-name="Rebelde" tvg-logo="https://image.xumo.com/v1/channels/channel/99951567/600x336.jpg?type=channelTile" group-title="xumo",Rebelde
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951567%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951197" tvg-name="Reuters 60" tvg-logo="https://image.xumo.com/v1/channels/channel/99951197/600x336.jpg?type=channelTile" group-title="xumo",Reuters 60
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951197%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991296" tvg-name="Revry" tvg-logo="https://image.xumo.com/v1/channels/channel/99991296/600x336.jpg?type=channelTile" group-title="xumo",Revry
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991296%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991106" tvg-name="RiffTrax" tvg-logo="https://image.xumo.com/v1/channels/channel/99991106/600x336.jpg?type=channelTile" group-title="xumo",RiffTrax
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991106%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951338" tvg-name="Rig TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951338/600x336.jpg?type=channelTile" group-title="xumo",Rig TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951338%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951373" tvg-name="Ryz Sports Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99951373/600x336.jpg?type=channelTile" group-title="xumo",Ryz Sports Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951373%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951236" tvg-name="SNL Vault" tvg-logo="https://image.xumo.com/v1/channels/channel/99951236/600x336.jpg?type=channelTile" group-title="xumo",SNL Vault
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951236%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951268" tvg-name="SPEEDVISION" tvg-logo="https://image.xumo.com/v1/channels/channel/99951268/600x336.jpg?type=channelTile" group-title="xumo",SPEEDVISION
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951268%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951211" tvg-name="STELLAR" tvg-logo="https://image.xumo.com/v1/channels/channel/99951211/600x336.jpg?type=channelTile" group-title="xumo",STELLAR
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951211%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951283" tvg-name="Salem News Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951283/600x336.jpg?type=channelTile" group-title="xumo",Salem News Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951283%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951247" tvg-name="Saved by the Bell" tvg-logo="https://image.xumo.com/v1/channels/channel/99951247/600x336.jpg?type=channelTile" group-title="xumo",Saved by the Bell
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951247%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951394" tvg-name="Say Yes to the Dress" tvg-logo="https://image.xumo.com/v1/channels/channel/99951394/600x336.jpg?type=channelTile" group-title="xumo",Say Yes to the Dress
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951394%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951349" tvg-name="Scares by Shudder" tvg-logo="https://image.xumo.com/v1/channels/channel/99951349/600x336.jpg?type=channelTile" group-title="xumo",Scares by Shudder
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951349%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991148" tvg-name="Scripps News" tvg-logo="https://image.xumo.com/v1/channels/channel/99991148/600x336.jpg?type=channelTile" group-title="xumo",Scripps News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991148%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951538" tvg-name="Scripps Sports Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99951538/600x336.jpg?type=channelTile" group-title="xumo",Scripps Sports Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951538%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951280" tvg-name="Sensical Jr." tvg-logo="https://image.xumo.com/v1/channels/channel/99951280/600x336.jpg?type=channelTile" group-title="xumo",Sensical Jr.
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951280%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995106" tvg-name="Shades of Black" tvg-logo="https://image.xumo.com/v1/channels/channel/9995106/600x336.jpg?type=channelTile" group-title="xumo",Shades of Black
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995106%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991370" tvg-name="ShopLC" tvg-logo="https://image.xumo.com/v1/channels/channel/99991370/600x336.jpg?type=channelTile" group-title="xumo",ShopLC
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991370%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951411" tvg-name="Shout! Movies" tvg-logo="https://image.xumo.com/v1/channels/channel/99951411/600x336.jpg?type=channelTile" group-title="xumo",Shout! Movies
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951411%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951223" tvg-name="Sky News" tvg-logo="https://image.xumo.com/v1/channels/channel/99951223/600x336.jpg?type=channelTile" group-title="xumo",Sky News
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951223%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951545" tvg-name="Space Live Powered by Sen" tvg-logo="https://image.xumo.com/v1/channels/channel/99951545/600x336.jpg?type=channelTile" group-title="xumo",Space Live Powered by Sen
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951545%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951528" tvg-name="SparkTV: Light & Love" tvg-logo="https://image.xumo.com/v1/channels/channel/99951528/600x336.jpg?type=channelTile" group-title="xumo",SparkTV: Light & Love
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951528%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951337" tvg-name="Spectrum News+" tvg-logo="https://image.xumo.com/v1/channels/channel/99951337/600x336.jpg?type=channelTile" group-title="xumo",Spectrum News+
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951337%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951414" tvg-name="Spectrum Noticias" tvg-logo="https://image.xumo.com/v1/channels/channel/99951414/600x336.jpg?type=channelTile" group-title="xumo",Spectrum Noticias
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951414%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991300" tvg-name="Stash TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991300/600x336.jpg?type=channelTile" group-title="xumo",Stash TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991300%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991119" tvg-name="Stingray Classic Rock" tvg-logo="https://image.xumo.com/v1/channels/channel/99991119/600x336.jpg?type=channelTile" group-title="xumo",Stingray Classic Rock
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991119%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991120" tvg-name="Stingray Greatest Hits" tvg-logo="https://image.xumo.com/v1/channels/channel/99991120/600x336.jpg?type=channelTile" group-title="xumo",Stingray Greatest Hits
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991120%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991117" tvg-name="Stingray Hit List" tvg-logo="https://image.xumo.com/v1/channels/channel/99991117/600x336.jpg?type=channelTile" group-title="xumo",Stingray Hit List
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991117%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991118" tvg-name="Stingray Hot Country" tvg-logo="https://image.xumo.com/v1/channels/channel/99991118/600x336.jpg?type=channelTile" group-title="xumo",Stingray Hot Country
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991118%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991252" tvg-name="Stingray Naturescape" tvg-logo="https://image.xumo.com/v1/channels/channel/99991252/600x336.jpg?type=channelTile" group-title="xumo",Stingray Naturescape
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991252%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991742" tvg-name="Stingray Remember the 80s" tvg-logo="https://image.xumo.com/v1/channels/channel/99991742/600x336.jpg?type=channelTile" group-title="xumo",Stingray Remember the 80s
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991742%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991121" tvg-name="Stingray Soul Storm" tvg-logo="https://image.xumo.com/v1/channels/channel/99991121/600x336.jpg?type=channelTile" group-title="xumo",Stingray Soul Storm
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991121%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951475" tvg-name="Storage Wars by A&E" tvg-logo="https://image.xumo.com/v1/channels/channel/99951475/600x336.jpg?type=channelTile" group-title="xumo",Storage Wars by A&E
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951475%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991622" tvg-name="Stories by AMC" tvg-logo="https://image.xumo.com/v1/channels/channel/99991622/600x336.jpg?type=channelTile" group-title="xumo",Stories by AMC
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991622%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951180" tvg-name="Strongman Champions League" tvg-logo="https://image.xumo.com/v1/channels/channel/99951180/600x336.jpg?type=channelTile" group-title="xumo",Strongman Champions League
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951180%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951126" tvg-name="Supermarket Sweep" tvg-logo="https://image.xumo.com/v1/channels/channel/99951126/600x336.jpg?type=channelTile" group-title="xumo",Supermarket Sweep
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951126%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951385" tvg-name="Sweet Escapes" tvg-logo="https://image.xumo.com/v1/channels/channel/99951385/600x336.jpg?type=channelTile" group-title="xumo",Sweet Escapes
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951385%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991696" tvg-name="Swerve Combat" tvg-logo="https://image.xumo.com/v1/channels/channel/99991696/600x336.jpg?type=channelTile" group-title="xumo",Swerve Combat
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991696%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991341" tvg-name="TNA Wrestling Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99991341/600x336.jpg?type=channelTile" group-title="xumo",TNA Wrestling Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991341%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991245" tvg-name="TODAY All Day" tvg-logo="https://image.xumo.com/v1/channels/channel/99991245/600x336.jpg?type=channelTile" group-title="xumo",TODAY All Day
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991245%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951299" tvg-name="TV One CRIME & JUSTICE FAST CHANNEL" tvg-logo="https://image.xumo.com/v1/channels/channel/99951299/600x336.jpg?type=channelTile" group-title="xumo",TV One CRIME & JUSTICE FAST CHANNEL
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951299%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951379" tvg-name="TV One Stars & Stories" tvg-logo="https://image.xumo.com/v1/channels/channel/99951379/600x336.jpg?type=channelTile" group-title="xumo",TV One Stars & Stories
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951379%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991147" tvg-name="TYT" tvg-logo="https://image.xumo.com/v1/channels/channel/99991147/600x336.jpg?type=channelTile" group-title="xumo",TYT
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991147%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991202" tvg-name="Tastemade" tvg-logo="https://image.xumo.com/v1/channels/channel/99991202/600x336.jpg?type=channelTile" group-title="xumo",Tastemade
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991202%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951436" tvg-name="Tastemade Home" tvg-logo="https://image.xumo.com/v1/channels/channel/99951436/600x336.jpg?type=channelTile" group-title="xumo",Tastemade Home
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951436%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995118" tvg-name="Tastemade Travel Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/9995118/600x336.jpg?type=channelTile" group-title="xumo",Tastemade Travel Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995118%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991748" tvg-name="Telemundo Acción" tvg-logo="https://image.xumo.com/v1/channels/channel/99991748/600x336.jpg?type=channelTile" group-title="xumo",Telemundo Acción
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991748%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991747" tvg-name="Telemundo Al Día" tvg-logo="https://image.xumo.com/v1/channels/channel/99991747/600x336.jpg?type=channelTile" group-title="xumo",Telemundo Al Día
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991747%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951459" tvg-name="Telemundo Deportes Ahora" tvg-logo="https://image.xumo.com/v1/channels/channel/99951459/600x336.jpg?type=channelTile" group-title="xumo",Telemundo Deportes Ahora
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951459%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951225" tvg-name="Telemundo Noticias California" tvg-logo="https://image.xumo.com/v1/channels/channel/99951225/600x336.jpg?type=channelTile" group-title="xumo",Telemundo Noticias California
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951225%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951227" tvg-name="Telemundo Noticias Florida" tvg-logo="https://image.xumo.com/v1/channels/channel/99951227/600x336.jpg?type=channelTile" group-title="xumo",Telemundo Noticias Florida
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951227%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951228" tvg-name="Telemundo Noticias Noreste" tvg-logo="https://image.xumo.com/v1/channels/channel/99951228/600x336.jpg?type=channelTile" group-title="xumo",Telemundo Noticias Noreste
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951228%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951226" tvg-name="Telemundo Noticias Texas" tvg-logo="https://image.xumo.com/v1/channels/channel/99951226/600x336.jpg?type=channelTile" group-title="xumo",Telemundo Noticias Texas
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951226%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991761" tvg-name="Teletubbies" tvg-logo="https://image.xumo.com/v1/channels/channel/99991761/600x336.jpg?type=channelTile" group-title="xumo",Teletubbies
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991761%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951389" tvg-name="TennisChannel 2" tvg-logo="https://image.xumo.com/v1/channels/channel/99951389/600x336.jpg?type=channelTile" group-title="xumo",TennisChannel 2
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951389%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991331" tvg-name="The Asylum" tvg-logo="https://image.xumo.com/v1/channels/channel/99991331/600x336.jpg?type=channelTile" group-title="xumo",The Asylum
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991331%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951476" tvg-name="The Bold and the Beautiful" tvg-logo="https://image.xumo.com/v1/channels/channel/99951476/600x336.jpg?type=channelTile" group-title="xumo",The Bold and the Beautiful
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951476%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951380" tvg-name="The Carol Burnett Show" tvg-logo="https://image.xumo.com/v1/channels/channel/99951380/600x336.jpg?type=channelTile" group-title="xumo",The Carol Burnett Show
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951380%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951224" tvg-name="The Celebrity Name Game Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951224/600x336.jpg?type=channelTile" group-title="xumo",The Celebrity Name Game Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951224%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951329" tvg-name="The Conners" tvg-logo="https://image.xumo.com/v1/channels/channel/99951329/600x336.jpg?type=channelTile" group-title="xumo",The Conners
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951329%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991390" tvg-name="The Design Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99991390/600x336.jpg?type=channelTile" group-title="xumo",The Design Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991390%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951400" tvg-name="The Ellen Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951400/600x336.jpg?type=channelTile" group-title="xumo",The Ellen Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951400%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951514" tvg-name="The Emeril Lagasse Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951514/600x336.jpg?type=channelTile" group-title="xumo",The Emeril Lagasse Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951514%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951395" tvg-name="The FBI" tvg-logo="https://image.xumo.com/v1/channels/channel/99951395/600x336.jpg?type=channelTile" group-title="xumo",The FBI
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951395%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951490" tvg-name="The First 48 by A&E" tvg-logo="https://image.xumo.com/v1/channels/channel/99951490/600x336.jpg?type=channelTile" group-title="xumo",The First 48 by A&E
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951490%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951450" tvg-name="The Graham Norton Show" tvg-logo="https://image.xumo.com/v1/channels/channel/99951450/600x336.jpg?type=channelTile" group-title="xumo",The Graham Norton Show
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951450%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951491" tvg-name="The Jack Hanna Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951491/600x336.jpg?type=channelTile" group-title="xumo",The Jack Hanna Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951491%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951153" tvg-name="The Jamie Oliver Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951153/600x336.jpg?type=channelTile" group-title="xumo",The Jamie Oliver Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951153%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951258" tvg-name="The Lone Ranger" tvg-logo="https://image.xumo.com/v1/channels/channel/99951258/600x336.jpg?type=channelTile" group-title="xumo",The Lone Ranger
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951258%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951513" tvg-name="The Martha Stewart Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951513/600x336.jpg?type=channelTile" group-title="xumo",The Martha Stewart Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951513%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951383" tvg-name="The NBA Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951383/600x336.jpg?type=channelTile" group-title="xumo",The NBA Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951383%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951408" tvg-name="The Osbournes" tvg-logo="https://image.xumo.com/v1/channels/channel/99951408/600x336.jpg?type=channelTile" group-title="xumo",The Osbournes
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951408%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991174" tvg-name="The Pet Collective" tvg-logo="https://image.xumo.com/v1/channels/channel/99991174/600x336.jpg?type=channelTile" group-title="xumo",The Pet Collective
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991174%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951125" tvg-name="The Price is Right: The Barker Era" tvg-logo="https://image.xumo.com/v1/channels/channel/99951125/600x336.jpg?type=channelTile" group-title="xumo",The Price is Right: The Barker Era
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951125%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951216" tvg-name="The Rifleman" tvg-logo="https://image.xumo.com/v1/channels/channel/99951216/600x336.jpg?type=channelTile" group-title="xumo",The Rifleman
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951216%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951525" tvg-name="The Virginian" tvg-logo="https://image.xumo.com/v1/channels/channel/99951525/600x336.jpg?type=channelTile" group-title="xumo",The Virginian
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951525%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991623" tvg-name="The Walking Dead Universe" tvg-logo="https://image.xumo.com/v1/channels/channel/99991623/600x336.jpg?type=channelTile" group-title="xumo",The Walking Dead Universe
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991623%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991745" tvg-name="The Wu Tang Collection TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991745/600x336.jpg?type=channelTile" group-title="xumo",The Wu Tang Collection TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991745%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951347" tvg-name="The Yorkshire Vet & Friends" tvg-logo="https://image.xumo.com/v1/channels/channel/99951347/600x336.jpg?type=channelTile" group-title="xumo",The Yorkshire Vet & Friends
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951347%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991293" tvg-name="This Old House" tvg-logo="https://image.xumo.com/v1/channels/channel/99991293/600x336.jpg?type=channelTile" group-title="xumo",This Old House
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991293%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951472" tvg-name="Tiny House Nation" tvg-logo="https://image.xumo.com/v1/channels/channel/99951472/600x336.jpg?type=channelTile" group-title="xumo",Tiny House Nation
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951472%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991759" tvg-name="Today's Homeowner" tvg-logo="https://image.xumo.com/v1/channels/channel/99991759/600x336.jpg?type=channelTile" group-title="xumo",Today's Homeowner
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991759%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991268" tvg-name="Toon Goggles" tvg-logo="https://image.xumo.com/v1/channels/channel/99991268/600x336.jpg?type=channelTile" group-title="xumo",Toon Goggles
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991268%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951249" tvg-name="Top Gear" tvg-logo="https://image.xumo.com/v1/channels/channel/99951249/600x336.jpg?type=channelTile" group-title="xumo",Top Gear
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951249%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951551" tvg-name="Torque by History" tvg-logo="https://image.xumo.com/v1/channels/channel/99951551/600x336.jpg?type=channelTile" group-title="xumo",Torque by History
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951551%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951443" tvg-name="Transformers" tvg-logo="https://image.xumo.com/v1/channels/channel/99951443/600x336.jpg?type=channelTile" group-title="xumo",Transformers
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951443%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991708" tvg-name="Trinity Broadcast Network" tvg-logo="https://image.xumo.com/v1/channels/channel/99991708/600x336.jpg?type=channelTile" group-title="xumo",Trinity Broadcast Network
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991708%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951531" tvg-name="Triton Poker" tvg-logo="https://image.xumo.com/v1/channels/channel/99951531/600x336.jpg?type=channelTile" group-title="xumo",Triton Poker
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951531%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991650" tvg-name="True History Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99991650/600x336.jpg?type=channelTile" group-title="xumo",True History Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991650%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951134" tvg-name="UFC" tvg-logo="https://image.xumo.com/v1/channels/channel/99951134/600x336.jpg?type=channelTile" group-title="xumo",UFC
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951134%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951552" tvg-name="UnXplained Zone" tvg-logo="https://image.xumo.com/v1/channels/channel/99951552/600x336.jpg?type=channelTile" group-title="xumo",UnXplained Zone
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951552%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951566" tvg-name="Una Familia de Diez" tvg-logo="https://image.xumo.com/v1/channels/channel/99951566/600x336.jpg?type=channelTile" group-title="xumo",Una Familia de Diez
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951566%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951369" tvg-name="Unbeaten Sports Channel" tvg-logo="https://image.xumo.com/v1/channels/channel/99951369/600x336.jpg?type=channelTile" group-title="xumo",Unbeaten Sports Channel
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951369%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951254" tvg-name="Universal Action" tvg-logo="https://image.xumo.com/v1/channels/channel/99951254/600x336.jpg?type=channelTile" group-title="xumo",Universal Action
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951254%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951245" tvg-name="Universal Crime" tvg-logo="https://image.xumo.com/v1/channels/channel/99951245/600x336.jpg?type=channelTile" group-title="xumo",Universal Crime
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951245%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951264" tvg-name="Universal Monsters" tvg-logo="https://image.xumo.com/v1/channels/channel/99951264/600x336.jpg?type=channelTile" group-title="xumo",Universal Monsters
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951264%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991621" tvg-name="Universal Movies" tvg-logo="https://image.xumo.com/v1/channels/channel/99991621/600x336.jpg?type=channelTile" group-title="xumo",Universal Movies
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991621%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951255" tvg-name="Universal Westerns" tvg-logo="https://image.xumo.com/v1/channels/channel/99951255/600x336.jpg?type=channelTile" group-title="xumo",Universal Westerns
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951255%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991680" tvg-name="Unsolved Mysteries" tvg-logo="https://image.xumo.com/v1/channels/channel/99991680/600x336.jpg?type=channelTile" group-title="xumo",Unsolved Mysteries
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991680%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951341" tvg-name="Untold Stories of the ER" tvg-logo="https://image.xumo.com/v1/channels/channel/99951341/600x336.jpg?type=channelTile" group-title="xumo",Untold Stories of the ER
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951341%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951453" tvg-name="Vice Entertainment" tvg-logo="https://image.xumo.com/v1/channels/channel/99951453/600x336.jpg?type=channelTile" group-title="xumo",Vice Entertainment
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951453%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995107" tvg-name="WFTV Orlando" tvg-logo="https://image.xumo.com/v1/channels/channel/9995107/600x336.jpg?type=channelTile" group-title="xumo",WFTV Orlando
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995107%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995109" tvg-name="WHIO Dayton" tvg-logo="https://image.xumo.com/v1/channels/channel/9995109/600x336.jpg?type=channelTile" group-title="xumo",WHIO Dayton
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995109%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951403" tvg-name="WITZ Comedy" tvg-logo="https://image.xumo.com/v1/channels/channel/99951403/600x336.jpg?type=channelTile" group-title="xumo",WITZ Comedy
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951403%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991689" tvg-name="WPXI Pittsburgh" tvg-logo="https://image.xumo.com/v1/channels/channel/99991689/600x336.jpg?type=channelTile" group-title="xumo",WPXI Pittsburgh
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991689%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991690" tvg-name="WSB Atlanta" tvg-logo="https://image.xumo.com/v1/channels/channel/99991690/600x336.jpg?type=channelTile" group-title="xumo",WSB Atlanta
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991690%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991691" tvg-name="WSOC Charlotte" tvg-logo="https://image.xumo.com/v1/channels/channel/99991691/600x336.jpg?type=channelTile" group-title="xumo",WSOC Charlotte
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991691%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991358" tvg-name="Waypoint TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991358/600x336.jpg?type=channelTile" group-title="xumo",Waypoint TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991358%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951535" tvg-name="Weeds & Nurse Jackie" tvg-logo="https://image.xumo.com/v1/channels/channel/99951535/600x336.jpg?type=channelTile" group-title="xumo",Weeds & Nurse Jackie
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951535%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951433" tvg-name="Wendy Williams" tvg-logo="https://image.xumo.com/v1/channels/channel/99951433/600x336.jpg?type=channelTile" group-title="xumo",Wendy Williams
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951433%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951160" tvg-name="Western Bound Wrangled by INSP" tvg-logo="https://image.xumo.com/v1/channels/channel/99951160/600x336.jpg?type=channelTile" group-title="xumo",Western Bound Wrangled by INSP
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951160%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951356" tvg-name="Wild West TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951356/600x336.jpg?type=channelTile" group-title="xumo",Wild West TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951356%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991628" tvg-name="WildEarth" tvg-logo="https://image.xumo.com/v1/channels/channel/99991628/600x336.jpg?type=channelTile" group-title="xumo",WildEarth
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991628%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951406" tvg-name="Willow Sports" tvg-logo="https://image.xumo.com/v1/channels/channel/99951406/600x336.jpg?type=channelTile" group-title="xumo",Willow Sports
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951406%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991317" tvg-name="World Poker Tour" tvg-logo="https://image.xumo.com/v1/channels/channel/99991317/600x336.jpg?type=channelTile" group-title="xumo",World Poker Tour
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991317%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951508" tvg-name="World of Love Island" tvg-logo="https://image.xumo.com/v1/channels/channel/99951508/600x336.jpg?type=channelTile" group-title="xumo",World of Love Island
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951508%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951544" tvg-name="World's Wildest Police Videos" tvg-logo="https://image.xumo.com/v1/channels/channel/99951544/600x336.jpg?type=channelTile" group-title="xumo",World's Wildest Police Videos
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951544%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951412" tvg-name="Xena Warrior Princess" tvg-logo="https://image.xumo.com/v1/channels/channel/99951412/600x336.jpg?type=channelTile" group-title="xumo",Xena Warrior Princess
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951412%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951554" tvg-name="Xtreme Outdoor by History" tvg-logo="https://image.xumo.com/v1/channels/channel/99951554/600x336.jpg?type=channelTile" group-title="xumo",Xtreme Outdoor by History
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951554%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991784" tvg-name="Xumo Free Action & Drama TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991784/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Action & Drama TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991784%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991105" tvg-name="Xumo Free Comedy TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991105/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Comedy TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991105%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991384" tvg-name="Xumo Free Crime TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991384/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Crime TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991384%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995117" tvg-name="Xumo Free Food TV" tvg-logo="https://image.xumo.com/v1/channels/channel/9995117/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Food TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995117%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991639" tvg-name="Xumo Free Game Show TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991639/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Game Show TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991639%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991107" tvg-name="Xumo Free Kids TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991107/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Kids TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991107%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951218" tvg-name="Xumo Free Nature & Wildlife TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99951218/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Nature & Wildlife TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951218%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991364" tvg-name="Xumo Free Reality TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991364/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Reality TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991364%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991111" tvg-name="Xumo Free Travel & Lifestyle TV" tvg-logo="https://image.xumo.com/v1/channels/channel/99991111/600x336.jpg?type=channelTile" group-title="xumo",Xumo Free Travel & Lifestyle TV
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991111%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951563" tvg-name="Zona TUDN" tvg-logo="https://image.xumo.com/v1/channels/channel/99951563/600x336.jpg?type=channelTile" group-title="xumo",Zona TUDN
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951563%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991387" tvg-name="beIN SPORTS XTRA" tvg-logo="https://image.xumo.com/v1/channels/channel/99991387/600x336.jpg?type=channelTile" group-title="xumo",beIN SPORTS XTRA
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991387%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99991785" tvg-name="beIN SPORTS XTRA en Español" tvg-logo="https://image.xumo.com/v1/channels/channel/99991785/600x336.jpg?type=channelTile" group-title="xumo",beIN SPORTS XTRA en Español
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99991785%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995103" tvg-name="iHeart Hip Hop Beats" tvg-logo="https://image.xumo.com/v1/channels/channel/9995103/600x336.jpg?type=channelTile" group-title="xumo",iHeart Hip Hop Beats
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995103%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995100" tvg-name="iHeart90s" tvg-logo="https://image.xumo.com/v1/channels/channel/9995100/600x336.jpg?type=channelTile" group-title="xumo",iHeart90s
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995100%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="9995102" tvg-name="iHeartCountry" tvg-logo="https://image.xumo.com/v1/channels/channel/9995102/600x336.jpg?type=channelTile" group-title="xumo",iHeartCountry
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F9995102%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="99951464" tvg-name="iHeartCountry Classics" tvg-logo="https://image.xumo.com/v1/channels/channel/99951464/600x336.jpg?type=channelTile" group-title="xumo",iHeartCountry Classics
+http://localhost:3000/api/ext/v1/xumo/https%3A%2F%2Fvalencia-app-mds.xumo.com%2Fv2%2Fchannels%2Fchannel%2F99951464%2Fbroadcast.json?token=1f3e916c43f6abb9a0400f72350062ef&pl=xumo
+#EXTINF:-1 tvg-id="62ba60f059624e000781c436" tvg-name="00s Replay" tvg-logo="https://images.pluto.tv/channels/62ba60f059624e000781c436/colorLogoPNG.png" group-title="pluto",00s Replay
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F62ba60f059624e000781c436?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6176f39e709f160007ec61c3" tvg-name="48 Hours" tvg-logo="https://images.pluto.tv/channels/6176f39e709f160007ec61c3/colorLogoPNG.png" group-title="pluto",48 Hours
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6176f39e709f160007ec61c3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68487fb3f212bedacf5a53e3" tvg-name="50 Cent Action" tvg-logo="https://images.pluto.tv/channels/68487fb3f212bedacf5a53e3/colorLogoPNG_1749846553889.png" group-title="pluto",50 Cent Action
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68487fb3f212bedacf5a53e3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66b646f9cd0d3100086af83c" tvg-name="60 Minutes" tvg-logo="https://images.pluto.tv/channels/66b646f9cd0d3100086af83c/colorLogoPNG.png" group-title="pluto",60 Minutes
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66b646f9cd0d3100086af83c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f4d878d3d19b30007d2e782" tvg-name="70s Cinema" tvg-logo="https://images.pluto.tv/channels/5f4d878d3d19b30007d2e782/colorLogoPNG.png" group-title="pluto",70s Cinema
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f4d878d3d19b30007d2e782?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ca525b650be2571e3943c63" tvg-name="80s Rewind" tvg-logo="https://images.pluto.tv/channels/5ca525b650be2571e3943c63/colorLogoPNG.png" group-title="pluto",80s Rewind
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ca525b650be2571e3943c63?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6452c814939a590008567a3b" tvg-name="90's Kids" tvg-logo="https://images.pluto.tv/channels/6452c814939a590008567a3b/colorLogoPNG_1731836283044.png" group-title="pluto",90's Kids
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6452c814939a590008567a3b?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6452c77ed3fdde00080eb3a8" tvg-name="90s Kids TV 2" tvg-logo="https://images.pluto.tv/channels/6452c77ed3fdde00080eb3a8/colorLogoPNG.png" group-title="pluto",90s Kids TV 2
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6452c77ed3fdde00080eb3a8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f4d86f519358a00072b978e" tvg-name="90s Throwback" tvg-logo="https://images.pluto.tv/channels/5f4d86f519358a00072b978e/colorLogoPNG.png" group-title="pluto",90s Throwback
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f4d86f519358a00072b978e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6000a5a9e767980007b497ca" tvg-name="A&E Crime 360" tvg-logo="https://images.pluto.tv/channels/6000a5a9e767980007b497ca/colorLogoPNG_1767745470551.png" group-title="pluto",A&E Crime 360
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6000a5a9e767980007b497ca?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6508be683a0d700008c534e4" tvg-name="ABC News Live" tvg-logo="https://images.pluto.tv/channels/6508be683a0d700008c534e4/colorLogoPNG.png" group-title="pluto",ABC News Live
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6508be683a0d700008c534e4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6793ea255225b515b4ba91a7" tvg-name="ALLBLK Gems" tvg-logo="https://images.pluto.tv/channels/6793ea255225b515b4ba91a7/colorLogoPNG.png" group-title="pluto",ALLBLK Gems
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6793ea255225b515b4ba91a7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6793eaa4bc03978b9bc63db1" tvg-name="ANIME x HIDIVE" tvg-logo="https://images.pluto.tv/channels/6793eaa4bc03978b9bc63db1/colorLogoPNG_1746815871603.png" group-title="pluto",ANIME x HIDIVE
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6793eaa4bc03978b9bc63db1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="682e43b21295f98347710917" tvg-name="AWSN" tvg-logo="https://images.pluto.tv/channels/682e43b21295f98347710917/colorLogoPNG_1748886692805.png" group-title="pluto",AWSN
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F682e43b21295f98347710917?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64dab1f835425100080e1e7b" tvg-name="Acapulco Shore" tvg-logo="https://images.pluto.tv/channels/64dab1f835425100080e1e7b/colorLogoPNG_1751300628513.png" group-title="pluto",Acapulco Shore
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64dab1f835425100080e1e7b?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e82530945600e0007ca076c" tvg-name="All Reality WE tv" tvg-logo="https://images.pluto.tv/channels/5e82530945600e0007ca076c/colorLogoPNG.png" group-title="pluto",All Reality WE tv
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e82530945600e0007ca076c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69eaa34817801c84fca05d94" tvg-name="Always Funny" tvg-logo="https://images.pluto.tv/channels/69eaa34817801c84fca05d94/colorLogoPNG_1777656411046.png" group-title="pluto",Always Funny
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69eaa34817801c84fca05d94?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="691cf0410a78a9ce61ad2121" tvg-name="America's Funniest Home Videos" tvg-logo="https://images.pluto.tv/channels/691cf0410a78a9ce61ad2121/colorLogoPNG_1767642885256.png" group-title="pluto",America's Funniest Home Videos
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F691cf0410a78a9ce61ad2121?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68757c45759366af05b3b199" tvg-name="America's Next Top Model" tvg-logo="https://images.pluto.tv/channels/68757c45759366af05b3b199/colorLogoPNG-1756852664017.png" group-title="pluto",America's Next Top Model
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68757c45759366af05b3b199?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e84f54a82f05300080e6746" tvg-name="America's Test Kitchen" tvg-logo="https://images.pluto.tv/channels/5e84f54a82f05300080e6746/colorLogoPNG.png" group-title="pluto",America's Test Kitchen
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e84f54a82f05300080e6746?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e1f7da4bc7d740009831259" tvg-name="America's Voice News" tvg-logo="https://images.pluto.tv/channels/5e1f7da4bc7d740009831259/colorLogoPNG.png" group-title="pluto",America's Voice News
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e1f7da4bc7d740009831259?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65492fc7056b9700088560b5" tvg-name="American Crimes" tvg-logo="https://images.pluto.tv/channels/65492fc7056b9700088560b5/colorLogoPNG_1763432008789.png" group-title="pluto",American Crimes
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65492fc7056b9700088560b5?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6887a8fd8e92b5e0a7244e88" tvg-name="Ancient Aliens" tvg-logo="https://images.pluto.tv/channels/6887a8fd8e92b5e0a7244e88/colorLogoPNG_1753992701393.png" group-title="pluto",Ancient Aliens
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6887a8fd8e92b5e0a7244e88?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66c638726838ee00085ac20d" tvg-name="Andromeda" tvg-logo="https://images.pluto.tv/channels/66c638726838ee00085ac20d/colorLogoPNG_1772843691075.png" group-title="pluto",Andromeda
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66c638726838ee00085ac20d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="615b8ec39e878900073f419a" tvg-name="Antiques Road Trip" tvg-logo="https://images.pluto.tv/channels/615b8ec39e878900073f419a/colorLogoPNG.png" group-title="pluto",Antiques Road Trip
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F615b8ec39e878900073f419a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ce44810b421747ae467b7cd" tvg-name="Antiques Roadshow UK" tvg-logo="https://images.pluto.tv/channels/5ce44810b421747ae467b7cd/colorLogoPNG_1782832480489.png" group-title="pluto",Antiques Roadshow UK
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ce44810b421747ae467b7cd?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="656535fc2c46f30008870fae" tvg-name="BBC Earth" tvg-logo="https://images.pluto.tv/channels/656535fc2c46f30008870fae/colorLogoPNG.png" group-title="pluto",BBC Earth
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F656535fc2c46f30008870fae?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65d92a8c8b24c80008e285c0" tvg-name="BBC News" tvg-logo="https://images.pluto.tv/channels/65d92a8c8b24c80008e285c0/colorLogoPNG.png" group-title="pluto",BBC News
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65d92a8c8b24c80008e285c0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="58af4c093a41ca9d4ecabe96" tvg-name="BET Cinema" tvg-logo="https://images.pluto.tv/channels/58af4c093a41ca9d4ecabe96/colorLogoPNG_1759338280891.png" group-title="pluto",BET Cinema
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F58af4c093a41ca9d4ecabe96?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60f85644a9493e0007a1f035" tvg-name="BET Classics" tvg-logo="https://images.pluto.tv/channels/60f85644a9493e0007a1f035/colorLogoPNG_1759339662769.png" group-title="pluto",BET Classics
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60f85644a9493e0007a1f035?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68c32d88f56983aba40052bd" tvg-name="BET Comedy Movies" tvg-logo="https://images.pluto.tv/channels/68c32d88f56983aba40052bd/colorLogoPNG_1759246622596.png" group-title="pluto",BET Comedy Movies
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68c32d88f56983aba40052bd?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68f690e7a25ba0aab32bed92" tvg-name="BET Holiday Movies" tvg-logo="https://images.pluto.tv/channels/68f690e7a25ba0aab32bed92/colorLogoPNG_1760989733981.png" group-title="pluto",BET Holiday Movies
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68f690e7a25ba0aab32bed92?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ca670f6593a5d78f0e85aed" tvg-name="BET Pluto TV" tvg-logo="https://images.pluto.tv/channels/5ca670f6593a5d78f0e85aed/colorLogoPNG.png" group-title="pluto",BET Pluto TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ca670f6593a5d78f0e85aed?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="61326275b3c86a00078e4833" tvg-name="BET Throwbacks" tvg-logo="https://images.pluto.tv/channels/61326275b3c86a00078e4833/colorLogoPNG_1759340015358.png" group-title="pluto",BET Throwbacks
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F61326275b3c86a00078e4833?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="663946c1b18d700008d9c168" tvg-name="BET Visionaries" tvg-logo="https://images.pluto.tv/channels/663946c1b18d700008d9c168/colorLogoPNG_1759338795452.png" group-title="pluto",BET Visionaries
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F663946c1b18d700008d9c168?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="666b265722acab000885c6aa" tvg-name="BET x Tyler Perry Comedy" tvg-logo="https://images.pluto.tv/channels/666b265722acab000885c6aa/colorLogoPNG.png" group-title="pluto",BET x Tyler Perry Comedy
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F666b265722acab000885c6aa?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="666b38a5efa2a10008b15b3a" tvg-name="BET x Tyler Perry Drama" tvg-logo="https://images.pluto.tv/channels/666b38a5efa2a10008b15b3a/colorLogoPNG.png" group-title="pluto",BET x Tyler Perry Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F666b38a5efa2a10008b15b3a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5812bfbe4ced4f7b601b12e6" tvg-name="BUZZR" tvg-logo="https://images.pluto.tv/channels/5812bfbe4ced4f7b601b12e6/colorLogoPNG.png" group-title="pluto",BUZZR
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5812bfbe4ced4f7b601b12e6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60faffc3fbbc120007fc4376" tvg-name="Baby Shark TV" tvg-logo="https://images.pluto.tv/channels/60faffc3fbbc120007fc4376/colorLogoPNG_1754073070812.png" group-title="pluto",Baby Shark TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60faffc3fbbc120007fc4376?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="654932fa4d6d8f00084c4723" tvg-name="Bad Girls Club" tvg-logo="https://images.pluto.tv/channels/654932fa4d6d8f00084c4723/colorLogoPNG.png" group-title="pluto",Bad Girls Club
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F654932fa4d6d8f00084c4723?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60a3d889a5b3690008dc7fe8" tvg-name="Bar Rescue" tvg-logo="https://images.pluto.tv/channels/60a3d889a5b3690008dc7fe8/colorLogoPNG_1780596469446.png" group-title="pluto",Bar Rescue
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60a3d889a5b3690008dc7fe8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69d7ebff029c431826bd328e" tvg-name="Battlestar Galactica" tvg-logo="https://images.pluto.tv/channels/69d7ebff029c431826bd328e/colorLogoPNG_1776982986391.png" group-title="pluto",Battlestar Galactica
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69d7ebff029c431826bd328e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68bb162bb3900870ec364cbe" tvg-name="Beach Day" tvg-logo="https://images.pluto.tv/channels/68bb162bb3900870ec364cbe/colorLogoPNG_1757977922278.png" group-title="pluto",Beach Day
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68bb162bb3900870ec364cbe?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ebc8688f3697d00072f7cf8" tvg-name="Bellator MMA" tvg-logo="https://images.pluto.tv/channels/5ebc8688f3697d00072f7cf8/colorLogoPNG.png" group-title="pluto",Bellator MMA
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ebc8688f3697d00072f7cf8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68bb167e00a2f063fdf7ee8f" tvg-name="Best of Bobby Flay by Food Network" tvg-logo="https://images.pluto.tv/channels/68bb167e00a2f063fdf7ee8f/colorLogoPNG_1757722144825.png" group-title="pluto",Best of Bobby Flay by Food Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68bb167e00a2f063fdf7ee8f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60f760bbdf090700075d7bfe" tvg-name="Best of Dr. Phil" tvg-logo="https://images.pluto.tv/channels/60f760bbdf090700075d7bfe/colorLogoPNG.png" group-title="pluto",Best of Dr. Phil
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60f760bbdf090700075d7bfe?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f7796e470510900070d4e3d" tvg-name="Beverly Hillbillies" tvg-logo="https://images.pluto.tv/channels/5f7796e470510900070d4e3d/colorLogoPNG_1731835751688.png" group-title="pluto",Beverly Hillbillies
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f7796e470510900070d4e3d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f4d83e0a382c00007bc02e7" tvg-name="Beverly Hills 90210" tvg-logo="https://images.pluto.tv/channels/5f4d83e0a382c00007bc02e7/colorLogoPNG.png" group-title="pluto",Beverly Hills 90210
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f4d83e0a382c00007bc02e7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="687ff00ff6bc08130f16ab81" tvg-name="Beyond the Gates" tvg-logo="https://images.pluto.tv/channels/687ff00ff6bc08130f16ab81/colorLogoPNG_1755074273752.png" group-title="pluto",Beyond the Gates
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F687ff00ff6bc08130f16ab81?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6661f11a41af6400080e90d8" tvg-name="Big Brother" tvg-logo="https://images.pluto.tv/channels/6661f11a41af6400080e90d8/colorLogoPNG.png" group-title="pluto",Big Brother
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6661f11a41af6400080e90d8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="686d61503484d6073283059d" tvg-name="Black Family Sitcoms" tvg-logo="https://images.pluto.tv/channels/686d61503484d6073283059d/colorLogoPNG_1752619670829.png" group-title="pluto",Black Family Sitcoms
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F686d61503484d6073283059d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d51e2bceca5b4b2c0e06c50" tvg-name="Black Ink Crew" tvg-logo="https://images.pluto.tv/channels/5d51e2bceca5b4b2c0e06c50/colorLogoPNG_1731835399139.png" group-title="pluto",Black Ink Crew
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d51e2bceca5b4b2c0e06c50?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e46fba0c43b0d00096e5ac1" tvg-name="Blaze Live" tvg-logo="https://images.pluto.tv/channels/5e46fba0c43b0d00096e5ac1/colorLogoPNG.png" group-title="pluto",Blaze Live
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e46fba0c43b0d00096e5ac1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="54ff7ba69222cb1c2624c584" tvg-name="Bloomberg TV+" tvg-logo="https://images.pluto.tv/channels/54ff7ba69222cb1c2624c584/colorLogoPNG_1756948295813.png" group-title="pluto",Bloomberg TV+
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F54ff7ba69222cb1c2624c584?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="61b3b8c645b45d0007a9bb8d" tvg-name="Blue Bloods" tvg-logo="https://images.pluto.tv/channels/61b3b8c645b45d0007a9bb8d/colorLogoPNG_1731834396573.png" group-title="pluto",Blue Bloods
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F61b3b8c645b45d0007a9bb8d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68e9913c4a666b9054849832" tvg-name="Bonanza" tvg-logo="https://images.pluto.tv/channels/68e9913c4a666b9054849832/colorLogoPNG_1762379692322.png" group-title="pluto",Bonanza
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68e9913c4a666b9054849832?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="696997049889f8db34c936c2" tvg-name="Boruto: Naruto Next Generations" tvg-logo="https://images.pluto.tv/channels/696997049889f8db34c936c2/colorLogoPNG_1771029425876.png" group-title="pluto",Boruto: Naruto Next Generations
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F696997049889f8db34c936c2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6176fd25e83a5f0007a464c9" tvg-name="Bounce XL" tvg-logo="https://images.pluto.tv/channels/6176fd25e83a5f0007a464c9/colorLogoPNG.png" group-title="pluto",Bounce XL
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6176fd25e83a5f0007a464c9?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6549310a53fc97000838fcc9" tvg-name="Bravo Vault" tvg-logo="https://images.pluto.tv/channels/6549310a53fc97000838fcc9/colorLogoPNG.png" group-title="pluto",Bravo Vault
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6549310a53fc97000838fcc9?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60f5d389985a0c0007357304" tvg-name="BritBox Mysteries" tvg-logo="https://images.pluto.tv/channels/60f5d389985a0c0007357304/colorLogoPNG.png" group-title="pluto",BritBox Mysteries
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60f5d389985a0c0007357304?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5a6b92f6e22a617379789618" tvg-name="CBS News 24/7" tvg-logo="https://images.pluto.tv/channels/5a6b92f6e22a617379789618/colorLogoPNG.png" group-title="pluto",CBS News 24/7
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5a6b92f6e22a617379789618?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60f75919718aed0007250d7a" tvg-name="CBS News Baltimore" tvg-logo="https://images.pluto.tv/channels/60f75919718aed0007250d7a/colorLogoPNG-1643042747442.png" group-title="pluto",CBS News Baltimore
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60f75919718aed0007250d7a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eb1afb21486df0007abc57c" tvg-name="CBS News Bay Area" tvg-logo="https://images.pluto.tv/channels/5eb1afb21486df0007abc57c/colorLogoPNG.png" group-title="pluto",CBS News Bay Area
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eb1afb21486df0007abc57c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eb1af2ad345340008fccd1e" tvg-name="CBS News Boston" tvg-logo="https://images.pluto.tv/channels/5eb1af2ad345340008fccd1e/colorLogoPNG.png" group-title="pluto",CBS News Boston
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eb1af2ad345340008fccd1e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eb1aeb2fd4b8a00076c2047" tvg-name="CBS News Chicago" tvg-logo="https://images.pluto.tv/channels/5eb1aeb2fd4b8a00076c2047/colorLogoPNG.png" group-title="pluto",CBS News Chicago
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eb1aeb2fd4b8a00076c2047?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eb1b12146cba40007aa7e5d" tvg-name="CBS News Colorado" tvg-logo="https://images.pluto.tv/channels/5eb1b12146cba40007aa7e5d/colorLogoPNG-1643041708234.png" group-title="pluto",CBS News Colorado
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eb1b12146cba40007aa7e5d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="634f2610d5023700078f7dee" tvg-name="CBS News Detroit" tvg-logo="https://images.pluto.tv/channels/634f2610d5023700078f7dee/colorLogoPNG.png" group-title="pluto",CBS News Detroit
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F634f2610d5023700078f7dee?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5dc9b875e280c80009a8a44a" tvg-name="CBS News Los Angeles" tvg-logo="https://images.pluto.tv/channels/5dc9b875e280c80009a8a44a/colorLogoPNG.png" group-title="pluto",CBS News Los Angeles
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5dc9b875e280c80009a8a44a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5dc481cda1d430000948a1b4" tvg-name="CBS News Los Angeles" tvg-logo="https://images.pluto.tv/channels/5dc481cda1d430000948a1b4/colorLogoPNG.png" group-title="pluto",CBS News Los Angeles
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5dc481cda1d430000948a1b4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60fb299b79498900070b29e0" tvg-name="CBS News Miami" tvg-logo="https://images.pluto.tv/channels/60fb299b79498900070b29e0/colorLogoPNG.png" group-title="pluto",CBS News Miami
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60fb299b79498900070b29e0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eb1b0bf2240d8000732a09c" tvg-name="CBS News Minnesota" tvg-logo="https://images.pluto.tv/channels/5eb1b0bf2240d8000732a09c/colorLogoPNG.png" group-title="pluto",CBS News Minnesota
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eb1b0bf2240d8000732a09c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5dc9b8223687ff000936ed79" tvg-name="CBS News New York" tvg-logo="https://images.pluto.tv/channels/5dc9b8223687ff000936ed79/colorLogoPNG.png" group-title="pluto",CBS News New York
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5dc9b8223687ff000936ed79?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5dc48170e280c80009a861ab" tvg-name="CBS News New York" tvg-logo="https://images.pluto.tv/channels/5dc48170e280c80009a861ab/colorLogoPNG.png" group-title="pluto",CBS News New York
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5dc48170e280c80009a861ab?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="62cdca1cda044a00077b903d" tvg-name="CBS News Philadelphia" tvg-logo="https://images.pluto.tv/channels/62cdca1cda044a00077b903d/colorLogoPNG.png" group-title="pluto",CBS News Philadelphia
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F62cdca1cda044a00077b903d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eb1b05ea168cc000767ba67" tvg-name="CBS News Philadelphia" tvg-logo="https://images.pluto.tv/channels/5eb1b05ea168cc000767ba67/colorLogoPNG.png" group-title="pluto",CBS News Philadelphia
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eb1b05ea168cc000767ba67?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eb1b17aa5277e00083f6521" tvg-name="CBS News Pittsburgh" tvg-logo="https://images.pluto.tv/channels/5eb1b17aa5277e00083f6521/colorLogoPNG.png" group-title="pluto",CBS News Pittsburgh
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eb1b17aa5277e00083f6521?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60cb6df2b2ad610008cd5bea" tvg-name="CBS News Sacramento" tvg-logo="https://images.pluto.tv/channels/60cb6df2b2ad610008cd5bea/colorLogoPNG.png" group-title="pluto",CBS News Sacramento
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60cb6df2b2ad610008cd5bea?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eceb0d4065c240007688ec6" tvg-name="CBS News Texas" tvg-logo="https://images.pluto.tv/channels/5eceb0d4065c240007688ec6/colorLogoPNG.png" group-title="pluto",CBS News Texas
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eceb0d4065c240007688ec6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e9f2c05172a0f0007db4786" tvg-name="CBS Sports HQ" tvg-logo="https://images.pluto.tv/channels/5e9f2c05172a0f0007db4786/colorLogoPNG_1731837352945.png" group-title="pluto",CBS Sports HQ
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e9f2c05172a0f0007db4786?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="668c5cb4f01dbe0008dd4082" tvg-name="CBS en español" tvg-logo="https://images.pluto.tv/channels/668c5cb4f01dbe0008dd4082/colorLogoPNG.png" group-title="pluto",CBS en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F668c5cb4f01dbe0008dd4082?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f68f53eb1e5800007390bf8" tvg-name="CMT Equal Play" tvg-logo="https://images.pluto.tv/channels/5f68f53eb1e5800007390bf8/colorLogoPNG.png" group-title="pluto",CMT Equal Play
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f68f53eb1e5800007390bf8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5421f71da6af422839419cb3" tvg-name="CNN HEADLINES" tvg-logo="https://images.pluto.tv/channels/5421f71da6af422839419cb3/colorLogoPNG_1755034025681.png" group-title="pluto",CNN HEADLINES
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5421f71da6af422839419cb3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="673248f9030a2c0008033af8" tvg-name="CNN Noticias" tvg-logo="https://images.pluto.tv/channels/673248f9030a2c0008033af8/colorLogoPNG_1777908720377.png" group-title="pluto",CNN Noticias
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F673248f9030a2c0008033af8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66e0b4536ad04d0008fff4b2" tvg-name="CNN Originals" tvg-logo="https://images.pluto.tv/channels/66e0b4536ad04d0008fff4b2/colorLogoPNG_1755018282136.png" group-title="pluto",CNN Originals
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66e0b4536ad04d0008fff4b2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e1f7e089f23700009d66303" tvg-name="COPS" tvg-logo="https://images.pluto.tv/channels/5e1f7e089f23700009d66303/colorLogoPNG.png" group-title="pluto",COPS
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e1f7e089f23700009d66303?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5efbd29e4aa26700076c0d06" tvg-name="CSI" tvg-logo="https://images.pluto.tv/channels/5efbd29e4aa26700076c0d06/colorLogoPNG.png" group-title="pluto",CSI
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5efbd29e4aa26700076c0d06?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="604928d54a4f730007ff76bc" tvg-name="CSI en Español" tvg-logo="https://images.pluto.tv/channels/604928d54a4f730007ff76bc/colorLogoPNG.png" group-title="pluto",CSI en Español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F604928d54a4f730007ff76bc?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="62f54c11b3af68000702c304" tvg-name="CSI: Miami" tvg-logo="https://images.pluto.tv/channels/62f54c11b3af68000702c304/colorLogoPNG_1731837343443.png" group-title="pluto",CSI: Miami
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F62f54c11b3af68000702c304?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="632b5950b515b000079e6b81" tvg-name="CSI: Miami en español" tvg-logo="https://images.pluto.tv/channels/632b5950b515b000079e6b81/colorLogoPNG_1731837336190.png" group-title="pluto",CSI: Miami en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F632b5950b515b000079e6b81?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="62f54c6439183b000769fb8f" tvg-name="CSI: NY" tvg-logo="https://images.pluto.tv/channels/62f54c6439183b000769fb8f/colorLogoPNG_1731837277521.png" group-title="pluto",CSI: NY
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F62f54c6439183b000769fb8f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="632b606e12a67b0007c9e371" tvg-name="CSI: NY en español" tvg-logo="https://images.pluto.tv/channels/632b606e12a67b0007c9e371/colorLogoPNG_1731837281479.png" group-title="pluto",CSI: NY en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F632b606e12a67b0007c9e371?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65244c403fd33c0008ffff31" tvg-name="Car Chase" tvg-logo="https://images.pluto.tv/channels/65244c403fd33c0008ffff31/colorLogoPNG.png" group-title="pluto",Car Chase
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65244c403fd33c0008ffff31?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60d393e5579a420007ee553c" tvg-name="Casos de la Dra. Polo" tvg-logo="https://images.pluto.tv/channels/60d393e5579a420007ee553c/colorLogoPNG.png" group-title="pluto",Casos de la Dra. Polo
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60d393e5579a420007ee553c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6a2b0d669465b98649cd0ba1" tvg-name="Charmed" tvg-logo="https://images.pluto.tv/channels/6a2b0d669465b98649cd0ba1/colorLogoPNG_1782946583491.png" group-title="pluto",Charmed
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6a2b0d669465b98649cd0ba1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="627d355aa95efd00077afcc7" tvg-name="Cheaters" tvg-logo="https://images.pluto.tv/channels/627d355aa95efd00077afcc7/colorLogoPNG.png" group-title="pluto",Cheaters
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F627d355aa95efd00077afcc7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6a28827ef4a627f3b07df1ea" tvg-name="Cheers" tvg-logo="https://images.pluto.tv/channels/6a28827ef4a627f3b07df1ea/colorLogoPNG_1781731467139.png" group-title="pluto",Cheers
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6a28827ef4a627f3b07df1ea?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68bb16a500a2f063fdf89f8c" tvg-name="Chef vs Chef by Food Network" tvg-logo="https://images.pluto.tv/channels/68bb16a500a2f063fdf89f8c/colorLogoPNG_1757718859405.png" group-title="pluto",Chef vs Chef by Food Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68bb16a500a2f063fdf89f8c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68bb16e7f89c82a68bcc4397" tvg-name="Chip & Jo: Feels Like Home by Magnolia Network" tvg-logo="https://images.pluto.tv/channels/68bb16e7f89c82a68bcc4397/colorLogoPNG_1758697632132.png" group-title="pluto",Chip & Jo: Feels Like Home by Magnolia Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68bb16e7f89c82a68bcc4397?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f5136317aedfb0007016f93" tvg-name="Cine Amor" tvg-logo="https://images.pluto.tv/channels/5f5136317aedfb0007016f93/colorLogoPNG_1757957531383.png" group-title="pluto",Cine Amor
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f5136317aedfb0007016f93?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cf968040ab7d8f181e6a68b" tvg-name="Cine Premiere" tvg-logo="https://images.pluto.tv/channels/5cf968040ab7d8f181e6a68b/colorLogoPNG.png" group-title="pluto",Cine Premiere
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cf968040ab7d8f181e6a68b?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d8d164d92e97a5e107638d2" tvg-name="Cine adrenalina" tvg-logo="https://images.pluto.tv/channels/5d8d164d92e97a5e107638d2/colorLogoPNG.png" group-title="pluto",Cine adrenalina
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d8d164d92e97a5e107638d2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60fb2f47c133270007327375" tvg-name="Cine aventura" tvg-logo="https://images.pluto.tv/channels/60fb2f47c133270007327375/colorLogoPNG_1757954279063.png" group-title="pluto",Cine aventura
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60fb2f47c133270007327375?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f513564e4622a0007c578c0" tvg-name="Cine comedia" tvg-logo="https://images.pluto.tv/channels/5f513564e4622a0007c578c0/colorLogoPNG_1757954361053.png" group-title="pluto",Cine comedia
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f513564e4622a0007c578c0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cf96b1c4f1ca3f0629f4bf0" tvg-name="Cine en español" tvg-logo="https://images.pluto.tv/channels/5cf96b1c4f1ca3f0629f4bf0/colorLogoPNG.png" group-title="pluto",Cine en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cf96b1c4f1ca3f0629f4bf0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6334a4d7ae975100073994a2" tvg-name="Cine navideño en Julio" tvg-logo="https://images.pluto.tv/channels/6334a4d7ae975100073994a2/colorLogoPNG_1782328486682.png" group-title="pluto",Cine navideño en Julio
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6334a4d7ae975100073994a2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d8d180092e97a5e107638d3" tvg-name="Cine terror" tvg-logo="https://images.pluto.tv/channels/5d8d180092e97a5e107638d3/colorLogoPNG.png" group-title="pluto",Cine terror
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d8d180092e97a5e107638d3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="61f33318210549000806a530" tvg-name="Classic Movie Westerns" tvg-logo="https://images.pluto.tv/channels/61f33318210549000806a530/colorLogoPNG.png" group-title="pluto",Classic Movie Westerns
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F61f33318210549000806a530?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="561c5b0dada51f8004c4d855" tvg-name="Classic Movies Channel" tvg-logo="https://images.pluto.tv/channels/561c5b0dada51f8004c4d855/colorLogoPNG_1759790242932.png" group-title="pluto",Classic Movies Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F561c5b0dada51f8004c4d855?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f15e32b297f96000768f928" tvg-name="Classic TV Comedy" tvg-logo="https://images.pluto.tv/channels/5f15e32b297f96000768f928/colorLogoPNG.png" group-title="pluto",Classic TV Comedy
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f15e32b297f96000768f928?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="61325c4f982acd000723287e" tvg-name="Classic TV Crime Drama" tvg-logo="https://images.pluto.tv/channels/61325c4f982acd000723287e/colorLogoPNG.png" group-title="pluto",Classic TV Crime Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F61325c4f982acd000723287e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f15e3cccf49290007053c67" tvg-name="Classic TV Drama" tvg-logo="https://images.pluto.tv/channels/5f15e3cccf49290007053c67/colorLogoPNG.png" group-title="pluto",Classic TV Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f15e3cccf49290007053c67?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="61325d18f5166c00081b84e0" tvg-name="Classic TV: Families" tvg-logo="https://images.pluto.tv/channels/61325d18f5166c00081b84e0/colorLogoPNG.png" group-title="pluto",Classic TV: Families
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F61325d18f5166c00081b84e0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f779951372da90007fd45e8" tvg-name="Classica" tvg-logo="https://images.pluto.tv/channels/5f779951372da90007fd45e8/colorLogoPNG.png" group-title="pluto",Classica
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f779951372da90007fd45e8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5c37d6712de254456f7ec340" tvg-name="Cold Case Files by A&E" tvg-logo="https://images.pluto.tv/channels/5c37d6712de254456f7ec340/colorLogoPNG_1767744689997.png" group-title="pluto",Cold Case Files by A&E
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5c37d6712de254456f7ec340?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ca671f215a62078d2ec0abf" tvg-name="Comedy Central Pluto TV" tvg-logo="https://images.pluto.tv/channels/5ca671f215a62078d2ec0abf/colorLogoPNG.png" group-title="pluto",Comedy Central Pluto TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ca671f215a62078d2ec0abf?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cf96dad1652631e36d43320" tvg-name="Comedy Central en español" tvg-logo="https://images.pluto.tv/channels/5cf96dad1652631e36d43320/colorLogoPNG_1731837238379.png" group-title="pluto",Comedy Central en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cf96dad1652631e36d43320?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="634ee8f95aa9870007248333" tvg-name="Confess by Nosey" tvg-logo="https://images.pluto.tv/channels/634ee8f95aa9870007248333/colorLogoPNG.png" group-title="pluto",Confess by Nosey
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F634ee8f95aa9870007248333?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="673249433a61d400087a51ed" tvg-name="Construcciones Asombrosas" tvg-logo="https://images.pluto.tv/channels/673249433a61d400087a51ed/colorLogoPNG_1732662528285.png" group-title="pluto",Construcciones Asombrosas
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F673249433a61d400087a51ed?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5dae0b4841a7d0000938ddbd" tvg-name="Court TV" tvg-logo="https://images.pluto.tv/channels/5dae0b4841a7d0000938ddbd/colorLogoPNG.png" group-title="pluto",Court TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5dae0b4841a7d0000938ddbd?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6732499ce40c4a0008bb9894" tvg-name="Crimen" tvg-logo="https://images.pluto.tv/channels/6732499ce40c4a0008bb9894/colorLogoPNG.png" group-title="pluto",Crimen
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6732499ce40c4a0008bb9894?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65653817c917a5000844bc30" tvg-name="Criminal Minds" tvg-logo="https://images.pluto.tv/channels/65653817c917a5000844bc30/colorLogoPNG.png" group-title="pluto",Criminal Minds
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65653817c917a5000844bc30?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65652f7fc0fc88000883537a" tvg-name="Crunchyroll" tvg-logo="https://images.pluto.tv/channels/65652f7fc0fc88000883537a/colorLogoPNG.png" group-title="pluto",Crunchyroll
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65652f7fc0fc88000883537a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e94cd036cc69d0007e8a1ba" tvg-name="Crímenes imperfectos" tvg-logo="https://images.pluto.tv/channels/5e94cd036cc69d0007e8a1ba/colorLogoPNG.png" group-title="pluto",Crímenes imperfectos
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e94cd036cc69d0007e8a1ba?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="649b6898f2ec0000081a9460" tvg-name="DAZN Ringside" tvg-logo="https://images.pluto.tv/channels/649b6898f2ec0000081a9460/colorLogoPNG.png" group-title="pluto",DAZN Ringside
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F649b6898f2ec0000081a9460?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d40855b3fb0855028c99b6f" tvg-name="DCC: Making the Team" tvg-logo="https://images.pluto.tv/channels/5d40855b3fb0855028c99b6f/colorLogoPNG.png" group-title="pluto",DCC: Making the Team
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d40855b3fb0855028c99b6f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="637413d8531e0c0007442d6d" tvg-name="Dateline 24/7" tvg-logo="https://images.pluto.tv/channels/637413d8531e0c0007442d6d/colorLogoPNG.png" group-title="pluto",Dateline 24/7
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F637413d8531e0c0007442d6d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="651f239d9c7aeb0008286823" tvg-name="Dating Disasters" tvg-logo="https://images.pluto.tv/channels/651f239d9c7aeb0008286823/colorLogoPNG.png" group-title="pluto",Dating Disasters
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F651f239d9c7aeb0008286823?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e9debf8c881310007d7bde1" tvg-name="Deal or No Deal" tvg-logo="https://images.pluto.tv/channels/5e9debf8c881310007d7bde1/colorLogoPNG.png" group-title="pluto",Deal or No Deal
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e9debf8c881310007d7bde1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5c6eeb85c05dfc257e5a50c4" tvg-name="Degrassi" tvg-logo="https://images.pluto.tv/channels/5c6eeb85c05dfc257e5a50c4/colorLogoPNG_1777484317786.png" group-title="pluto",Degrassi
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5c6eeb85c05dfc257e5a50c4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68bb16ba3efb41cd971f3ce6" tvg-name="Delicious Eats by Food Network" tvg-logo="https://images.pluto.tv/channels/68bb16ba3efb41cd971f3ce6/colorLogoPNG_1757719016994.png" group-title="pluto",Delicious Eats by Food Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68bb16ba3efb41cd971f3ce6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6a2b0eab9465b98649cd0d2f" tvg-name="Diagnosis Murder" tvg-logo="https://images.pluto.tv/channels/6a2b0eab9465b98649cd0d2f/colorLogoPNG_1782946685197.png" group-title="pluto",Diagnosis Murder
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6a2b0eab9465b98649cd0d2f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="673bf05ddaad7f0008ac7a5c" tvg-name="Dinos 24/7" tvg-logo="https://images.pluto.tv/channels/673bf05ddaad7f0008ac7a5c/colorLogoPNG.png" group-title="pluto",Dinos 24/7
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F673bf05ddaad7f0008ac7a5c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6400f731d200410008f9b339" tvg-name="Discovery Turbo TV" tvg-logo="https://images.pluto.tv/channels/6400f731d200410008f9b339/colorLogoPNG_1767979567752.png" group-title="pluto",Discovery Turbo TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6400f731d200410008f9b339?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ce4475cd43850831ca91ce7" tvg-name="Doctor Who Classic" tvg-logo="https://images.pluto.tv/channels/5ce4475cd43850831ca91ce7/colorLogoPNG.png" group-title="pluto",Doctor Who Classic
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ce4475cd43850831ca91ce7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="664fd48894d5580008e45e7c" tvg-name="Dog Whisperer with Cesar Millan" tvg-logo="https://images.pluto.tv/channels/664fd48894d5580008e45e7c/colorLogoPNG.png" group-title="pluto",Dog Whisperer with Cesar Millan
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F664fd48894d5580008e45e7c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5bee1a7359ee03633e780238" tvg-name="Dog the Bounty Hunter" tvg-logo="https://images.pluto.tv/channels/5bee1a7359ee03633e780238/colorLogoPNG_1767736765611.png" group-title="pluto",Dog the Bounty Hunter
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5bee1a7359ee03633e780238?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6a2b0f2509705ebdf781231d" tvg-name="Dr. Quinn, Medicine Woman" tvg-logo="https://images.pluto.tv/channels/6a2b0f2509705ebdf781231d/colorLogoPNG_1782946772357.png" group-title="pluto",Dr. Quinn, Medicine Woman
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6a2b0f2509705ebdf781231d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64d1606b4c5ed80008e3b8b9" tvg-name="Dynasty" tvg-logo="https://images.pluto.tv/channels/64d1606b4c5ed80008e3b8b9/colorLogoPNG_1731835571308.png" group-title="pluto",Dynasty
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64d1606b4c5ed80008e3b8b9?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5dc0c78281eddb0009a02d5e" tvg-name="ET" tvg-logo="https://images.pluto.tv/channels/5dc0c78281eddb0009a02d5e/colorLogoPNG.png" group-title="pluto",ET
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5dc0c78281eddb0009a02d5e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6675c713fc3a46000863dde7" tvg-name="Ebony TV Drama" tvg-logo="https://images.pluto.tv/channels/6675c713fc3a46000863dde7/colorLogoPNG.png" group-title="pluto",Ebony TV Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6675c713fc3a46000863dde7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66fedd65d7de140008dccd66" tvg-name="El Reino Infantil" tvg-logo="https://images.pluto.tv/channels/66fedd65d7de140008dccd66/colorLogoPNG.png" group-title="pluto",El Reino Infantil
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66fedd65d7de140008dccd66?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="691d1200c2185a44642f5e7c" tvg-name="El Rey Rebel" tvg-logo="https://images.pluto.tv/channels/691d1200c2185a44642f5e7c/colorLogoPNG_1764783865457.png" group-title="pluto",El Rey Rebel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F691d1200c2185a44642f5e7c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60492e6d7f3f560007ab0f62" tvg-name="Estrella News" tvg-logo="https://images.pluto.tv/channels/60492e6d7f3f560007ab0f62/colorLogoPNG.png" group-title="pluto",Estrella News
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60492e6d7f3f560007ab0f62?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cf0622da00ca1e2f6fac712" tvg-name="EstrellaTV" tvg-logo="https://images.pluto.tv/channels/5cf0622da00ca1e2f6fac712/colorLogoPNG.png" group-title="pluto",EstrellaTV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cf0622da00ca1e2f6fac712?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5a74b8e1e22a61737979c6bf" tvg-name="FOX Sports" tvg-logo="https://images.pluto.tv/channels/5a74b8e1e22a61737979c6bf/colorLogoPNG.png" group-title="pluto",FOX Sports
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5a74b8e1e22a61737979c6bf?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="640a68880e884c0009979cc2" tvg-name="FOX Weather" tvg-logo="https://images.pluto.tv/channels/640a68880e884c0009979cc2/colorLogoPNG_1779087602438.png" group-title="pluto",FOX Weather
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F640a68880e884c0009979cc2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="554158e864526b29254ff105" tvg-name="FailArmy" tvg-logo="https://images.pluto.tv/channels/554158e864526b29254ff105/colorLogoPNG.png" group-title="pluto",FailArmy
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F554158e864526b29254ff105?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="672e4d915534bb0008c50168" tvg-name="Family Feud" tvg-logo="https://images.pluto.tv/channels/672e4d915534bb0008c50168/colorLogoPNG_1732662454856.png" group-title="pluto",Family Feud
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F672e4d915534bb0008c50168?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="643f03b9d8436e0008edf021" tvg-name="Family Feud Classic" tvg-logo="https://images.pluto.tv/channels/643f03b9d8436e0008edf021/colorLogoPNG.png" group-title="pluto",Family Feud Classic
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F643f03b9d8436e0008edf021?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f77939a630f530007dde654" tvg-name="Family Ties" tvg-logo="https://images.pluto.tv/channels/5f77939a630f530007dde654/colorLogoPNG.png" group-title="pluto",Family Ties
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f77939a630f530007dde654?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="650b68bc2ce8e40008ac9c14" tvg-name="FanDuel TV Extra" tvg-logo="https://images.pluto.tv/channels/650b68bc2ce8e40008ac9c14/colorLogoPNG_1744930668027.png" group-title="pluto",FanDuel TV Extra
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F650b68bc2ce8e40008ac9c14?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65775af3b3801200084a3aa4" tvg-name="Feel Good Drama" tvg-logo="https://images.pluto.tv/channels/65775af3b3801200084a3aa4/colorLogoPNG.png" group-title="pluto",Feel Good Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65775af3b3801200084a3aa4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="614501c653ceee000772b0ca" tvg-name="Festive Fireplace" tvg-logo="https://images.pluto.tv/channels/614501c653ceee000772b0ca/colorLogoPNG.png" group-title="pluto",Festive Fireplace
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F614501c653ceee000772b0ca?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="58e55b14ad8e9c364d55f717" tvg-name="Flicks of Fury" tvg-logo="https://images.pluto.tv/channels/58e55b14ad8e9c364d55f717/colorLogoPNG.png" group-title="pluto",Flicks of Fury
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F58e55b14ad8e9c364d55f717?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5bb1af6a268cae539bcedb0a" tvg-name="Forensic Files" tvg-logo="https://images.pluto.tv/channels/5bb1af6a268cae539bcedb0a/colorLogoPNG.png" group-title="pluto",Forensic Files
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5bb1af6a268cae539bcedb0a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="56171fafada51f8004c4b40f" tvg-name="Forever Kids" tvg-logo="https://images.pluto.tv/channels/56171fafada51f8004c4b40f/colorLogoPNG.png" group-title="pluto",Forever Kids
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F56171fafada51f8004c4b40f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66ba495ffe11e5000881f049" tvg-name="Frasier" tvg-logo="https://images.pluto.tv/channels/66ba495ffe11e5000881f049/colorLogoPNG_1782142982491.png" group-title="pluto",Frasier
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66ba495ffe11e5000881f049?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="580e87ff497c73ba2f321dd3" tvg-name="Funny AF" tvg-logo="https://images.pluto.tv/channels/580e87ff497c73ba2f321dd3/colorLogoPNG.png" group-title="pluto",Funny AF
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F580e87ff497c73ba2f321dd3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e54187aae660e00093561d6" tvg-name="Game Show Central" tvg-logo="https://images.pluto.tv/channels/5e54187aae660e00093561d6/colorLogoPNG.png" group-title="pluto",Game Show Central
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e54187aae660e00093561d6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60faf9ddfcc1f200070a5932" tvg-name="Garfield and Friends" tvg-logo="https://images.pluto.tv/channels/60faf9ddfcc1f200070a5932/colorLogoPNG.png" group-title="pluto",Garfield and Friends
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60faf9ddfcc1f200070a5932?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64e561a4354251000823a0e0" tvg-name="Ghost Hunters" tvg-logo="https://images.pluto.tv/channels/64e561a4354251000823a0e0/colorLogoPNG.png" group-title="pluto",Ghost Hunters
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64e561a4354251000823a0e0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6a2b0e66c2b638404f0a4ffb" tvg-name="Ghost Whisperer" tvg-logo="https://images.pluto.tv/channels/6a2b0e66c2b638404f0a4ffb/colorLogoPNG_1782946863231.png" group-title="pluto",Ghost Whisperer
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6a2b0e66c2b638404f0a4ffb?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="667f3852efa2a10008e1e514" tvg-name="Go Go Gadget!" tvg-logo="https://images.pluto.tv/channels/667f3852efa2a10008e1e514/colorLogoPNG.png" group-title="pluto",Go Go Gadget!
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F667f3852efa2a10008e1e514?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="63a0e33a45264d000850ed7e" tvg-name="Golazo Network" tvg-logo="https://images.pluto.tv/channels/63a0e33a45264d000850ed7e/colorLogoPNG_1731835813404.png" group-title="pluto",Golazo Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F63a0e33a45264d000850ed7e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65493029ab052400089e9d2f" tvg-name="GolfPass" tvg-logo="https://images.pluto.tv/channels/65493029ab052400089e9d2f/colorLogoPNG_1766432879705.png" group-title="pluto",GolfPass
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65493029ab052400089e9d2f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5b4e99f4423e067bd6df6903" tvg-name="Gordon Ramsay's Hell's Kitchen" tvg-logo="https://images.pluto.tv/channels/5b4e99f4423e067bd6df6903/colorLogoPNG.png" group-title="pluto",Gordon Ramsay's Hell's Kitchen
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5b4e99f4423e067bd6df6903?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69699ae5d301d54fb3dc1499" tvg-name="GrowthDay Network" tvg-logo="https://images.pluto.tv/channels/69699ae5d301d54fb3dc1499/colorLogoPNG_1772167334184.png" group-title="pluto",GrowthDay Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69699ae5d301d54fb3dc1499?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60f75771dfc72a00071fd0e0" tvg-name="Gunsmoke" tvg-logo="https://images.pluto.tv/channels/60f75771dfc72a00071fd0e0/colorLogoPNG.png" group-title="pluto",Gunsmoke
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60f75771dfc72a00071fd0e0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f8a02476b72230007e62b7d" tvg-name="HSN" tvg-logo="https://images.pluto.tv/channels/5f8a02476b72230007e62b7d/colorLogoPNG_1779087603120.png" group-title="pluto",HSN
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f8a02476b72230007e62b7d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="628e685ba3811100070551a8" tvg-name="Hallmark Movies & More" tvg-logo="https://images.pluto.tv/channels/628e685ba3811100070551a8/colorLogoPNG_1767639054863.png" group-title="pluto",Hallmark Movies & More
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F628e685ba3811100070551a8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f7794162a4559000781fc12" tvg-name="Happy Days" tvg-logo="https://images.pluto.tv/channels/5f7794162a4559000781fc12/colorLogoPNG_1731835352299.png" group-title="pluto",Happy Days
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f7794162a4559000781fc12?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="61f07513227feb00073ee6bc" tvg-name="Heartland" tvg-logo="https://images.pluto.tv/channels/61f07513227feb00073ee6bc/colorLogoPNG.png" group-title="pluto",Heartland
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F61f07513227feb00073ee6bc?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66e0b4a3f0f17500085cc268" tvg-name="Hit Sitcoms" tvg-logo="https://images.pluto.tv/channels/66e0b4a3f0f17500085cc268/colorLogoPNG.png" group-title="pluto",Hit Sitcoms
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66e0b4a3f0f17500085cc268?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68939e206727ec919bb39061" tvg-name="Hogan's Heroes" tvg-logo="https://images.pluto.tv/channels/68939e206727ec919bb39061/colorLogoPNG_1757523507747.png" group-title="pluto",Hogan's Heroes
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68939e206727ec919bb39061?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68bb16916523408b14bac7f8" tvg-name="Home Cooking by Food Network" tvg-logo="https://images.pluto.tv/channels/68bb16916523408b14bac7f8/colorLogoPNG_1757969887631.png" group-title="pluto",Home Cooking by Food Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68bb16916523408b14bac7f8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5dc1cb279c91420009db261d" tvg-name="Home.Made.Nation" tvg-logo="https://images.pluto.tv/channels/5dc1cb279c91420009db261d/colorLogoPNG.png" group-title="pluto",Home.Made.Nation
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5dc1cb279c91420009db261d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66df8aa7abec540008ca8cb6" tvg-name="Homeful" tvg-logo="https://images.pluto.tv/channels/66df8aa7abec540008ca8cb6/colorLogoPNG.png" group-title="pluto",Homeful
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66df8aa7abec540008ca8cb6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6036e6e7ac69c400072afca2" tvg-name="Hot Bench" tvg-logo="https://images.pluto.tv/channels/6036e6e7ac69c400072afca2/colorLogoPNG_1731835667408.png" group-title="pluto",Hot Bench
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6036e6e7ac69c400072afca2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="634f3011f4fff20007431641" tvg-name="I Love Lucy" tvg-logo="https://images.pluto.tv/channels/634f3011f4fff20007431641/colorLogoPNG_1731836749484.png" group-title="pluto",I Love Lucy
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F634f3011f4fff20007431641?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65453f30085df200085883d8" tvg-name="ION" tvg-logo="https://images.pluto.tv/channels/65453f30085df200085883d8/colorLogoPNG.png" group-title="pluto",ION
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65453f30085df200085883d8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60807fd5db701400078219c2" tvg-name="Ink Master" tvg-logo="https://images.pluto.tv/channels/60807fd5db701400078219c2/colorLogoPNG_1731836032181.png" group-title="pluto",Ink Master
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60807fd5db701400078219c2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="67c63b90a20c0399a381b816" tvg-name="Inuyasha" tvg-logo="https://images.pluto.tv/channels/67c63b90a20c0399a381b816/colorLogoPNG_1745441127472.png" group-title="pluto",Inuyasha
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F67c63b90a20c0399a381b816?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cf96b8f4f1ca3f0629f4bf1" tvg-name="Investiga" tvg-logo="https://images.pluto.tv/channels/5cf96b8f4f1ca3f0629f4bf1/colorLogoPNG.png" group-title="pluto",Investiga
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cf96b8f4f1ca3f0629f4bf1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="609bfa51fbecc1000733152e" tvg-name="Jersey Shore" tvg-logo="https://images.pluto.tv/channels/609bfa51fbecc1000733152e/colorLogoPNG.png" group-title="pluto",Jersey Shore
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F609bfa51fbecc1000733152e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e9decb953e157000752321c" tvg-name="Judge Nosey" tvg-logo="https://images.pluto.tv/channels/5e9decb953e157000752321c/colorLogoPNG.png" group-title="pluto",Judge Nosey
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e9decb953e157000752321c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60fb040d4795a6000762fe8f" tvg-name="Kartoon Channel!" tvg-logo="https://images.pluto.tv/channels/60fb040d4795a6000762fe8f/colorLogoPNG.png" group-title="pluto",Kartoon Channel!
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60fb040d4795a6000762fe8f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5db0ad56edc89300090d2ebb" tvg-name="Kids Movie Club" tvg-logo="https://images.pluto.tv/channels/5db0ad56edc89300090d2ebb/colorLogoPNG.png" group-title="pluto",Kids Movie Club
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5db0ad56edc89300090d2ebb?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60fb01a24795a6000762fe83" tvg-name="LEGO Kids TV" tvg-logo="https://images.pluto.tv/channels/60fb01a24795a6000762fe83/colorLogoPNG.png" group-title="pluto",LEGO Kids TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60fb01a24795a6000762fe83?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="668c566d08d5490008075948" tvg-name="La Familia del Barrio" tvg-logo="https://images.pluto.tv/channels/668c566d08d5490008075948/colorLogoPNG.png" group-title="pluto",La Familia del Barrio
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F668c566d08d5490008075948?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68758038552299d2b08162e3" tvg-name="Law & Order" tvg-logo="https://images.pluto.tv/channels/68758038552299d2b08162e3/colorLogoPNG_1754039420438.png" group-title="pluto",Law & Order
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68758038552299d2b08162e3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6267352efcf21c0007c76642" tvg-name="Let's Make A Deal" tvg-logo="https://images.pluto.tv/channels/6267352efcf21c0007c76642/colorLogoPNG.png" group-title="pluto",Let's Make A Deal
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6267352efcf21c0007c76642?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="63335b193583440007c859fb" tvg-name="Lifetime Movie Favorites" tvg-logo="https://images.pluto.tv/channels/63335b193583440007c859fb/colorLogoPNG_1767722325837.png" group-title="pluto",Lifetime Movie Favorites
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F63335b193583440007c859fb?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5eb301b7395671000780d100" tvg-name="Little Angel's Playroom" tvg-logo="https://images.pluto.tv/channels/5eb301b7395671000780d100/colorLogoPNG.png" group-title="pluto",Little Angel's Playroom
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5eb301b7395671000780d100?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60493283ffc52f000710edae" tvg-name="Little Angel's Playroom en Español" tvg-logo="https://images.pluto.tv/channels/60493283ffc52f000710edae/colorLogoPNG.png" group-title="pluto",Little Angel's Playroom en Español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60493283ffc52f000710edae?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="654933ac986ad20008a1f406" tvg-name="Little House on the Prairie" tvg-logo="https://images.pluto.tv/channels/654933ac986ad20008a1f406/colorLogoPNG.png" group-title="pluto",Little House on the Prairie
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F654933ac986ad20008a1f406?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="51c75f7bb6f26ba1cd00002f" tvg-name="Little Stars Universe" tvg-logo="https://images.pluto.tv/channels/51c75f7bb6f26ba1cd00002f/colorLogoPNG.png" group-title="pluto",Little Stars Universe
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F51c75f7bb6f26ba1cd00002f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5873fc21cad696fb37aa9054" tvg-name="Live Music" tvg-logo="https://images.pluto.tv/channels/5873fc21cad696fb37aa9054/colorLogoPNG.png" group-title="pluto",Live Music
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5873fc21cad696fb37aa9054?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6887a4e01067b66fa16966ec" tvg-name="Live PD Presents" tvg-logo="https://images.pluto.tv/channels/6887a4e01067b66fa16966ec/colorLogoPNG_1757525803914.png" group-title="pluto",Live PD Presents
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6887a4e01067b66fa16966ec?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="63d025db4e83e700086eaa96" tvg-name="LiveNOW from FOX" tvg-logo="https://images.pluto.tv/channels/63d025db4e83e700086eaa96/colorLogoPNG.png" group-title="pluto",LiveNOW from FOX
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F63d025db4e83e700086eaa96?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68bb164fb3900870ec368759" tvg-name="Living With Evil" tvg-logo="https://images.pluto.tv/channels/68bb164fb3900870ec368759/colorLogoPNG_1757981472717.png" group-title="pluto",Living With Evil
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68bb164fb3900870ec368759?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ce5a8954311f992edbe1da2" tvg-name="Logo Pluto TV" tvg-logo="https://images.pluto.tv/channels/5ce5a8954311f992edbe1da2/colorLogoPNG_1731836723261.png" group-title="pluto",Logo Pluto TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ce5a8954311f992edbe1da2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d51ddf0369acdb278dfb05e" tvg-name="Love & Hip Hop" tvg-logo="https://images.pluto.tv/channels/5d51ddf0369acdb278dfb05e/colorLogoPNG.png" group-title="pluto",Love & Hip Hop
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d51ddf0369acdb278dfb05e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66df8a29b25d2b0008fc5fe0" tvg-name="Love Nature" tvg-logo="https://images.pluto.tv/channels/66df8a29b25d2b0008fc5fe0/colorLogoPNG.png" group-title="pluto",Love Nature
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66df8a29b25d2b0008fc5fe0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e66968a70f34c0007d050be" tvg-name="MLB" tvg-logo="https://images.pluto.tv/channels/5e66968a70f34c0007d050be/colorLogoPNG.png" group-title="pluto",MLB
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e66968a70f34c0007d050be?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="545943f1c9f133a519bbac92" tvg-name="MST3K" tvg-logo="https://images.pluto.tv/channels/545943f1c9f133a519bbac92/colorLogoPNG.png" group-title="pluto",MST3K
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F545943f1c9f133a519bbac92?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d14fd1a252d35decbc4080c" tvg-name="MTV Biggest Pop" tvg-logo="https://images.pluto.tv/channels/5d14fd1a252d35decbc4080c/colorLogoPNG_1758324914960.png" group-title="pluto",MTV Biggest Pop
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d14fd1a252d35decbc4080c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d3609cd6a6c78d7672f2a81" tvg-name="MTV Flow Latino" tvg-logo="https://images.pluto.tv/channels/5d3609cd6a6c78d7672f2a81/colorLogoPNG_1731834717093.png" group-title="pluto",MTV Flow Latino
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d3609cd6a6c78d7672f2a81?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ca672f515a62078d2ec0ad2" tvg-name="MTV Pluto TV" tvg-logo="https://images.pluto.tv/channels/5ca672f515a62078d2ec0ad2/colorLogoPNG.png" group-title="pluto",MTV Pluto TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ca672f515a62078d2ec0ad2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d14fdb8ca91eedee1633117" tvg-name="MTV Spankin' New" tvg-logo="https://images.pluto.tv/channels/5d14fdb8ca91eedee1633117/colorLogoPNG.png" group-title="pluto",MTV Spankin' New
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d14fdb8ca91eedee1633117?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cf96d351652631e36d4331f" tvg-name="MTV en español" tvg-logo="https://images.pluto.tv/channels/5cf96d351652631e36d4331f/colorLogoPNG-1641928405432.png" group-title="pluto",MTV en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cf96d351652631e36d4331f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6887a86be3703b7d42b3eca3" tvg-name="Matched Married Meet by Lifetime" tvg-logo="https://images.pluto.tv/channels/6887a86be3703b7d42b3eca3/colorLogoPNG_1757524386570.png" group-title="pluto",Matched Married Meet by Lifetime
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6887a86be3703b7d42b3eca3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60f754f98185580007eb0754" tvg-name="Matlock" tvg-logo="https://images.pluto.tv/channels/60f754f98185580007eb0754/colorLogoPNG_1731836706925.png" group-title="pluto",Matlock
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60f754f98185580007eb0754?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64d2b6bf9b414d0008187d83" tvg-name="Mayday: Air Disaster" tvg-logo="https://images.pluto.tv/channels/64d2b6bf9b414d0008187d83/colorLogoPNG_1780955414910.png" group-title="pluto",Mayday: Air Disaster
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64d2b6bf9b414d0008187d83?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cbf6a868a1bce4a3d52a5e9" tvg-name="Midsomer Murders" tvg-logo="https://images.pluto.tv/channels/5cbf6a868a1bce4a3d52a5e9/colorLogoPNG.png" group-title="pluto",Midsomer Murders
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cbf6a868a1bce4a3d52a5e9?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6549322e53fc97000838febc" tvg-name="Million Dollar Listing Vault" tvg-logo="https://images.pluto.tv/channels/6549322e53fc97000838febc/colorLogoPNG.png" group-title="pluto",Million Dollar Listing Vault
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6549322e53fc97000838febc?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f77977bd924d80007eee60c" tvg-name="Mission Impossible" tvg-logo="https://images.pluto.tv/channels/5f77977bd924d80007eee60c/colorLogoPNG_1731835516936.png" group-title="pluto",Mission Impossible
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f77977bd924d80007eee60c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65e23f340d4561000821540d" tvg-name="Mister Rogers' Neighborhood" tvg-logo="https://images.pluto.tv/channels/65e23f340d4561000821540d/colorLogoPNG.png" group-title="pluto",Mister Rogers' Neighborhood
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65e23f340d4561000821540d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f4d882d5233170007ee880e" tvg-name="Misterios sin resolver" tvg-logo="https://images.pluto.tv/channels/5f4d882d5233170007ee880e/colorLogoPNG.png" group-title="pluto",Misterios sin resolver
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f4d882d5233170007ee880e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65775d29dfed030008cb3db2" tvg-name="Modern Marvels by HISTORY" tvg-logo="https://images.pluto.tv/channels/65775d29dfed030008cb3db2/colorLogoPNG.png" group-title="pluto",Modern Marvels by HISTORY
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65775d29dfed030008cb3db2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65c69b683ba51e00084534a3" tvg-name="Monster Jam" tvg-logo="https://images.pluto.tv/channels/65c69b683ba51e00084534a3/colorLogoPNG.png" group-title="pluto",Monster Jam
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65c69b683ba51e00084534a3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="613260e4bdb71c00070d63fa" tvg-name="More TV Drama" tvg-logo="https://images.pluto.tv/channels/613260e4bdb71c00070d63fa/colorLogoPNG.png" group-title="pluto",More TV Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F613260e4bdb71c00070d63fa?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6132619f9ddaa50007e7dd86" tvg-name="More TV Sitcoms" tvg-logo="https://images.pluto.tv/channels/6132619f9ddaa50007e7dd86/colorLogoPNG.png" group-title="pluto",More TV Sitcoms
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6132619f9ddaa50007e7dd86?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6532e6a9bdf3cf000887ab29" tvg-name="More True Crime" tvg-logo="https://images.pluto.tv/channels/6532e6a9bdf3cf000887ab29/colorLogoPNG.png" group-title="pluto",More True Crime
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6532e6a9bdf3cf000887ab29?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="645e7828e1979c00087b75b4" tvg-name="MovieSphere by Lionsgate" tvg-logo="https://images.pluto.tv/channels/645e7828e1979c00087b75b4/colorLogoPNG.png" group-title="pluto",MovieSphere by Lionsgate
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F645e7828e1979c00087b75b4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6549337183595c000815ad05" tvg-name="Murder, She Wrote" tvg-logo="https://images.pluto.tv/channels/6549337183595c000815ad05/colorLogoPNG.png" group-title="pluto",Murder, She Wrote
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6549337183595c000815ad05?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66e0b4866ad04d0008fff4d8" tvg-name="MythBusters" tvg-logo="https://images.pluto.tv/channels/66e0b4866ad04d0008fff4d8/colorLogoPNG.png" group-title="pluto",MythBusters
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66e0b4866ad04d0008fff4d8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="687fea9a4fa995eff284a1c8" tvg-name="Más adrenalina" tvg-logo="https://images.pluto.tv/channels/687fea9a4fa995eff284a1c8/colorLogoPNG_1755151031497.png" group-title="pluto",Más adrenalina
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F687fea9a4fa995eff284a1c8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5df97894467dfa00091c873c" tvg-name="NBC News NOW" tvg-logo="https://images.pluto.tv/channels/5df97894467dfa00091c873c/colorLogoPNG.png" group-title="pluto",NBC News NOW
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5df97894467dfa00091c873c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6549306c83595c000815a696" tvg-name="NBC Sports NOW" tvg-logo="https://images.pluto.tv/channels/6549306c83595c000815a696/colorLogoPNG.png" group-title="pluto",NBC Sports NOW
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6549306c83595c000815a696?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ced7d5df64be98e07ed47b6" tvg-name="NFL Channel" tvg-logo="https://images.pluto.tv/channels/5ced7d5df64be98e07ed47b6/colorLogoPNG.png" group-title="pluto",NFL Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ced7d5df64be98e07ed47b6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5da0c85bd2c9c10009370984" tvg-name="Naruto" tvg-logo="https://images.pluto.tv/channels/5da0c85bd2c9c10009370984/colorLogoPNG.png" group-title="pluto",Naruto
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5da0c85bd2c9c10009370984?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6675c742ca74680008566b88" tvg-name="Nash Bridges" tvg-logo="https://images.pluto.tv/channels/6675c742ca74680008566b88/colorLogoPNG.png" group-title="pluto",Nash Bridges
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6675c742ca74680008566b88?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5812bd9f249444e05d09cc4e" tvg-name="Naturescape" tvg-logo="https://images.pluto.tv/channels/5812bd9f249444e05d09cc4e/colorLogoPNG.png" group-title="pluto",Naturescape
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5812bd9f249444e05d09cc4e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5fff49cfb5cd4f0007c2b0dc" tvg-name="News 12 New York" tvg-logo="https://images.pluto.tv/channels/5fff49cfb5cd4f0007c2b0dc/colorLogoPNG.png" group-title="pluto",News 12 New York
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5fff49cfb5cd4f0007c2b0dc?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="55b179af994403942f3061d6" tvg-name="Newsmax2" tvg-logo="https://images.pluto.tv/channels/55b179af994403942f3061d6/colorLogoPNG.png" group-title="pluto",Newsmax2
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F55b179af994403942f3061d6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ca6748a37b88b269472dad9" tvg-name="Nick Jr. Pluto TV" tvg-logo="https://images.pluto.tv/channels/5ca6748a37b88b269472dad9/colorLogoPNG.png" group-title="pluto",Nick Jr. Pluto TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ca6748a37b88b269472dad9?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ca673e0d0bd6c2689c94ce3" tvg-name="Nickelodeon Pluto TV" tvg-logo="https://images.pluto.tv/channels/5ca673e0d0bd6c2689c94ce3/colorLogoPNG.png" group-title="pluto",Nickelodeon Pluto TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ca673e0d0bd6c2689c94ce3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d8d08395f39465da6fb3ec4" tvg-name="Nickelodeon en español" tvg-logo="https://images.pluto.tv/channels/5d8d08395f39465da6fb3ec4/colorLogoPNG.png" group-title="pluto",Nickelodeon en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d8d08395f39465da6fb3ec4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66ff0cf663292d0008320cf8" tvg-name="No Reservations" tvg-logo="https://images.pluto.tv/channels/66ff0cf663292d0008320cf8/colorLogoPNG.png" group-title="pluto",No Reservations
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66ff0cf663292d0008320cf8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5aec96ec5126c2157123c657" tvg-name="Nosey" tvg-logo="https://images.pluto.tv/channels/5aec96ec5126c2157123c657/colorLogoPNG.png" group-title="pluto",Nosey
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5aec96ec5126c2157123c657?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e7cf6c7b156d500078c5f44" tvg-name="OAN Plus" tvg-logo="https://images.pluto.tv/channels/5e7cf6c7b156d500078c5f44/colorLogoPNG.png" group-title="pluto",OAN Plus
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e7cf6c7b156d500078c5f44?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f7790b3ed0c88000720b241" tvg-name="One Piece" tvg-logo="https://images.pluto.tv/channels/5f7790b3ed0c88000720b241/colorLogoPNG_1731837233662.png" group-title="pluto",One Piece
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f7790b3ed0c88000720b241?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="654930a8346f420008d3b0b8" tvg-name="Oxygen True Crime Archives" tvg-logo="https://images.pluto.tv/channels/654930a8346f420008d3b0b8/colorLogoPNG.png" group-title="pluto",Oxygen True Crime Archives
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F654930a8346f420008d3b0b8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60d39387706fe50007fda8e8" tvg-name="PBR RidePass" tvg-logo="https://images.pluto.tv/channels/60d39387706fe50007fda8e8/colorLogoPNG.png" group-title="pluto",PBR RidePass
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60d39387706fe50007fda8e8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="636c2b3c55d2e700074105c4" tvg-name="PBS Antiques Roadshow" tvg-logo="https://images.pluto.tv/channels/636c2b3c55d2e700074105c4/colorLogoPNG.png" group-title="pluto",PBS Antiques Roadshow
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F636c2b3c55d2e700074105c4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="640a64bd73e013000893d4e0" tvg-name="PBS Nature" tvg-logo="https://images.pluto.tv/channels/640a64bd73e013000893d4e0/colorLogoPNG.png" group-title="pluto",PBS Nature
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F640a64bd73e013000893d4e0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6334a574605f140007e233c4" tvg-name="PFL MMA" tvg-logo="https://images.pluto.tv/channels/6334a574605f140007e233c4/colorLogoPNG.png" group-title="pluto",PFL MMA
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6334a574605f140007e233c4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5de94dacb394a300099fa22a" tvg-name="PGA TOUR" tvg-logo="https://images.pluto.tv/channels/5de94dacb394a300099fa22a/colorLogoPNG.png" group-title="pluto",PGA TOUR
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5de94dacb394a300099fa22a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="63b48016d9dd51000828fa37" tvg-name="POWERNATION" tvg-logo="https://images.pluto.tv/channels/63b48016d9dd51000828fa37/colorLogoPNG.png" group-title="pluto",POWERNATION
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F63b48016d9dd51000828fa37?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cb0cae7a461406ffe3f5213" tvg-name="Paramount Movie Channel" tvg-logo="https://images.pluto.tv/channels/5cb0cae7a461406ffe3f5213/colorLogoPNG.png" group-title="pluto",Paramount Movie Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cb0cae7a461406ffe3f5213?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ff8c708653d080007361b14" tvg-name="Paramount+ Picks" tvg-logo="https://images.pluto.tv/channels/5ff8c708653d080007361b14/colorLogoPNG.png" group-title="pluto",Paramount+ Picks
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ff8c708653d080007361b14?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d14fb6c84dd37df3b4290c5" tvg-name="Peppa Pig" tvg-logo="https://images.pluto.tv/channels/5d14fb6c84dd37df3b4290c5/colorLogoPNG_1730733871298.png" group-title="pluto",Peppa Pig
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d14fb6c84dd37df3b4290c5?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6197086891ddd4000739941a" tvg-name="Perry Mason" tvg-logo="https://images.pluto.tv/channels/6197086891ddd4000739941a/colorLogoPNG_1731835750293.png" group-title="pluto",Perry Mason
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6197086891ddd4000739941a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6565413e4261ca0008215320" tvg-name="Pickers & Pawn" tvg-logo="https://images.pluto.tv/channels/6565413e4261ca0008215320/colorLogoPNG.png" group-title="pluto",Pickers & Pawn
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6565413e4261ca0008215320?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66e0b265dd2d690008c5496b" tvg-name="Places & Spaces" tvg-logo="https://images.pluto.tv/channels/66e0b265dd2d690008c5496b/colorLogoPNG.png" group-title="pluto",Places & Spaces
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66e0b265dd2d690008c5496b?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="561d7d484dc7c8770484914a" tvg-name="Pluto TV Action" tvg-logo="https://images.pluto.tv/channels/561d7d484dc7c8770484914a/colorLogoPNG.png" group-title="pluto",Pluto TV Action
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F561d7d484dc7c8770484914a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69d7ebb726eeec84158e28cb" tvg-name="Pluto TV Adventure" tvg-logo="https://images.pluto.tv/channels/69d7ebb726eeec84158e28cb/colorLogoPNG_1777587473079.png" group-title="pluto",Pluto TV Adventure
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69d7ebb726eeec84158e28cb?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5812b7d3249444e05d09cc49" tvg-name="Pluto TV Anime" tvg-logo="https://images.pluto.tv/channels/5812b7d3249444e05d09cc49/colorLogoPNG_1748797351518.png" group-title="pluto",Pluto TV Anime
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5812b7d3249444e05d09cc49?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="67ed8f7e443f0671bc2b2368" tvg-name="Pluto TV Anime Movies" tvg-logo="https://images.pluto.tv/channels/67ed8f7e443f0671bc2b2368/colorLogoPNG_1747069531459.png" group-title="pluto",Pluto TV Anime Movies
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F67ed8f7e443f0671bc2b2368?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cabdf1437b88b26947346b2" tvg-name="Pluto TV Backcountry" tvg-logo="https://images.pluto.tv/channels/5cabdf1437b88b26947346b2/colorLogoPNG.png" group-title="pluto",Pluto TV Backcountry
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cabdf1437b88b26947346b2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5812b3a4249444e05d09cc46" tvg-name="Pluto TV Cars" tvg-logo="https://images.pluto.tv/channels/5812b3a4249444e05d09cc46/colorLogoPNG.png" group-title="pluto",Pluto TV Cars
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5812b3a4249444e05d09cc46?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="63335df531a7590007c226b9" tvg-name="Pluto TV Christmas in July" tvg-logo="https://images.pluto.tv/channels/63335df531a7590007c226b9/colorLogoPNG_1781050123940.png" group-title="pluto",Pluto TV Christmas in July
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F63335df531a7590007c226b9?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5a4d3a00ad95e4718ae8d8db" tvg-name="Pluto TV Comedy" tvg-logo="https://images.pluto.tv/channels/5a4d3a00ad95e4718ae8d8db/colorLogoPNG_1731836724642.png" group-title="pluto",Pluto TV Comedy
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5a4d3a00ad95e4718ae8d8db?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="603fde9026ecbf0007752c2c" tvg-name="Pluto TV Competition" tvg-logo="https://images.pluto.tv/channels/603fde9026ecbf0007752c2c/colorLogoPNG.png" group-title="pluto",Pluto TV Competition
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F603fde9026ecbf0007752c2c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f31fd1b4c510e00071c3103" tvg-name="Pluto TV Crime Drama" tvg-logo="https://images.pluto.tv/channels/5f31fd1b4c510e00071c3103/colorLogoPNG.png" group-title="pluto",Pluto TV Crime Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f31fd1b4c510e00071c3103?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f4d8594eb979c0007706de7" tvg-name="Pluto TV Crime Movies" tvg-logo="https://images.pluto.tv/channels/5f4d8594eb979c0007706de7/colorLogoPNG.png" group-title="pluto",Pluto TV Crime Movies
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f4d8594eb979c0007706de7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5c665db3e6c01b72c4977bc2" tvg-name="Pluto TV Cult Films" tvg-logo="https://images.pluto.tv/channels/5c665db3e6c01b72c4977bc2/colorLogoPNG.png" group-title="pluto",Pluto TV Cult Films
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5c665db3e6c01b72c4977bc2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5b4e92e4694c027be6ecece1" tvg-name="Pluto TV Drama" tvg-logo="https://images.pluto.tv/channels/5b4e92e4694c027be6ecece1/colorLogoPNG.png" group-title="pluto",Pluto TV Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5b4e92e4694c027be6ecece1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5b64a245a202b3337f09e51d" tvg-name="Pluto TV Fantastic" tvg-logo="https://images.pluto.tv/channels/5b64a245a202b3337f09e51d/colorLogoPNG_1756834917957.png" group-title="pluto",Pluto TV Fantastic
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5b64a245a202b3337f09e51d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69fa471bc2b638404ffa91bf" tvg-name="Pluto TV Fireworks" tvg-logo="https://images.pluto.tv/channels/69fa471bc2b638404ffa91bf/colorLogoPNG_1781130983128.png" group-title="pluto",Pluto TV Fireworks
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69fa471bc2b638404ffa91bf?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68fbf8101d26140175db8b58" tvg-name="Pluto TV Franchise Favorites" tvg-logo="https://images.pluto.tv/channels/68fbf8101d26140175db8b58/colorLogoPNG_1762383685562.png" group-title="pluto",Pluto TV Franchise Favorites
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68fbf8101d26140175db8b58?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6036e7c385749f00075dbd3b" tvg-name="Pluto TV Game Shows" tvg-logo="https://images.pluto.tv/channels/6036e7c385749f00075dbd3b/colorLogoPNG.png" group-title="pluto",Pluto TV Game Shows
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6036e7c385749f00075dbd3b?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5a4d35dfa5c02e717a234f86" tvg-name="Pluto TV History" tvg-logo="https://images.pluto.tv/channels/5a4d35dfa5c02e717a234f86/colorLogoPNG.png" group-title="pluto",Pluto TV History
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5a4d35dfa5c02e717a234f86?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69d6c7befde57cd5ba0160c3" tvg-name="Pluto TV Hometown Drama" tvg-logo="https://images.pluto.tv/channels/69d6c7befde57cd5ba0160c3/colorLogoPNG_1777488284970.png" group-title="pluto",Pluto TV Hometown Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69d6c7befde57cd5ba0160c3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="569546031a619b8f07ce6e25" tvg-name="Pluto TV Horror" tvg-logo="https://images.pluto.tv/channels/569546031a619b8f07ce6e25/colorLogoPNG.png" group-title="pluto",Pluto TV Horror
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F569546031a619b8f07ce6e25?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64b585f84ea480000838e446" tvg-name="Pluto TV Icons" tvg-logo="https://images.pluto.tv/channels/64b585f84ea480000838e446/colorLogoPNG.png" group-title="pluto",Pluto TV Icons
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64b585f84ea480000838e446?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d8beeb39b5d5d5f8c672530" tvg-name="Pluto TV Lives" tvg-logo="https://images.pluto.tv/channels/5d8beeb39b5d5d5f8c672530/colorLogoPNG.png" group-title="pluto",Pluto TV Lives
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d8beeb39b5d5d5f8c672530?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5bb3fea0f711fd76340eebff" tvg-name="Pluto TV Military" tvg-logo="https://images.pluto.tv/channels/5bb3fea0f711fd76340eebff/colorLogoPNG.png" group-title="pluto",Pluto TV Military
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5bb3fea0f711fd76340eebff?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d9ccd538661290009ecbdb7" tvg-name="Pluto TV Mistletoe" tvg-logo="https://images.pluto.tv/channels/5d9ccd538661290009ecbdb7/colorLogoPNG_1762555055191.png" group-title="pluto",Pluto TV Mistletoe
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d9ccd538661290009ecbdb7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cf96c0222df39f1a338d163" tvg-name="Pluto TV Novelas" tvg-logo="https://images.pluto.tv/channels/5cf96c0222df39f1a338d163/colorLogoPNG.png" group-title="pluto",Pluto TV Novelas
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cf96c0222df39f1a338d163?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5adf96e3e738977e2c31cb04" tvg-name="Pluto TV Paranormal" tvg-logo="https://images.pluto.tv/channels/5adf96e3e738977e2c31cb04/colorLogoPNG.png" group-title="pluto",Pluto TV Paranormal
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5adf96e3e738977e2c31cb04?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69fa3faab9c0f0d444e64de3" tvg-name="Pluto TV Pride" tvg-logo="https://images.pluto.tv/channels/69fa3faab9c0f0d444e64de3/colorLogoPNG_1779985115765.png" group-title="pluto",Pluto TV Pride
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69fa3faab9c0f0d444e64de3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="617b37b361e0fd0008cfd8c5" tvg-name="Pluto TV Reaction" tvg-logo="https://images.pluto.tv/channels/617b37b361e0fd0008cfd8c5/colorLogoPNG_1731837948814.png" group-title="pluto",Pluto TV Reaction
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F617b37b361e0fd0008cfd8c5?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d8bf0b06d2d855ee15115e3" tvg-name="Pluto TV Reality" tvg-logo="https://images.pluto.tv/channels/5d8bf0b06d2d855ee15115e3/colorLogoPNG.png" group-title="pluto",Pluto TV Reality
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d8bf0b06d2d855ee15115e3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5a66795ef91fef2c7031c599" tvg-name="Pluto TV Romance" tvg-logo="https://images.pluto.tv/channels/5a66795ef91fef2c7031c599/colorLogoPNG.png" group-title="pluto",Pluto TV Romance
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5a66795ef91fef2c7031c599?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5b4fc274694c027be6ed3eea" tvg-name="Pluto TV Sci-Fi" tvg-logo="https://images.pluto.tv/channels/5b4fc274694c027be6ed3eea/colorLogoPNG.png" group-title="pluto",Pluto TV Sci-Fi
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5b4fc274694c027be6ed3eea?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="563a970aa1a1f7fe7c9daad7" tvg-name="Pluto TV Science" tvg-logo="https://images.pluto.tv/channels/563a970aa1a1f7fe7c9daad7/colorLogoPNG.png" group-title="pluto",Pluto TV Science
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F563a970aa1a1f7fe7c9daad7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ba3fb9c4b078e0f37ad34e8" tvg-name="Pluto TV Spotlight" tvg-logo="https://images.pluto.tv/channels/5ba3fb9c4b078e0f37ad34e8/colorLogoPNG.png" group-title="pluto",Pluto TV Spotlight
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ba3fb9c4b078e0f37ad34e8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f4d863b98b41000076cd061" tvg-name="Pluto TV Staff Picks" tvg-logo="https://images.pluto.tv/channels/5f4d863b98b41000076cd061/colorLogoPNG.png" group-title="pluto",Pluto TV Staff Picks
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f4d863b98b41000076cd061?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5c6dc88fcd232425a6e0f06e" tvg-name="Pluto TV Terror" tvg-logo="https://images.pluto.tv/channels/5c6dc88fcd232425a6e0f06e/colorLogoPNG.png" group-title="pluto",Pluto TV Terror
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5c6dc88fcd232425a6e0f06e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5b4e69e08291147bd04a9fd7" tvg-name="Pluto TV Thrillers" tvg-logo="https://images.pluto.tv/channels/5b4e69e08291147bd04a9fd7/colorLogoPNG.png" group-title="pluto",Pluto TV Thrillers
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5b4e69e08291147bd04a9fd7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="673247127d5da5000817b4d6" tvg-name="Pluto TV Trending Now" tvg-logo="https://images.pluto.tv/channels/673247127d5da5000817b4d6/colorLogoPNG_1732662634386.png" group-title="pluto",Pluto TV Trending Now
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F673247127d5da5000817b4d6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5812be1c249444e05d09cc50" tvg-name="Pluto TV True Crime" tvg-logo="https://images.pluto.tv/channels/5812be1c249444e05d09cc50/colorLogoPNG.png" group-title="pluto",Pluto TV True Crime
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5812be1c249444e05d09cc50?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5b4e94282d4ec87bdcbb87cd" tvg-name="Pluto TV Westerns" tvg-logo="https://images.pluto.tv/channels/5b4e94282d4ec87bdcbb87cd/colorLogoPNG.png" group-title="pluto",Pluto TV Westerns
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5b4e94282d4ec87bdcbb87cd?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5fc54366b04b2300072e31af" tvg-name="PokerGO" tvg-logo="https://images.pluto.tv/channels/5fc54366b04b2300072e31af/colorLogoPNG.png" group-title="pluto",PokerGO
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5fc54366b04b2300072e31af?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6675c7868768aa0008d7f1c7" tvg-name="Pokémon" tvg-logo="https://images.pluto.tv/channels/6675c7868768aa0008d7f1c7/colorLogoPNG.png" group-title="pluto",Pokémon
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6675c7868768aa0008d7f1c7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69e6be40fde57cd5ba562b29" tvg-name="Pokémon en español" tvg-logo="https://images.pluto.tv/channels/69e6be40fde57cd5ba562b29/colorLogoPNG_1777592109830.png" group-title="pluto",Pokémon en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69e6be40fde57cd5ba562b29?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68757c60552299d2b080eab6" tvg-name="Project Runway" tvg-logo="https://images.pluto.tv/channels/68757c60552299d2b080eab6/colorLogoPNG_1753221108158.png" group-title="pluto",Project Runway
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68757c60552299d2b080eab6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="698384cb7230043f21f4a3f4" tvg-name="Property Brothers" tvg-logo="https://images.pluto.tv/channels/698384cb7230043f21f4a3f4/colorLogoPNG_1771374915234.png" group-title="pluto",Property Brothers
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F698384cb7230043f21f4a3f4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5bdcdf1e851dd5632e2c11d1" tvg-name="QVC" tvg-logo="https://images.pluto.tv/channels/5bdcdf1e851dd5632e2c11d1/colorLogoPNG.png" group-title="pluto",QVC
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5bdcdf1e851dd5632e2c11d1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="67817323dd7846fe546940dd" tvg-name="QVC2" tvg-logo="https://images.pluto.tv/channels/67817323dd7846fe546940dd/colorLogoPNG.png" group-title="pluto",QVC2
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F67817323dd7846fe546940dd?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="696998915a0ae9e1b563f0c6" tvg-name="Qello Concerts" tvg-logo="https://images.pluto.tv/channels/696998915a0ae9e1b563f0c6/colorLogoPNG_1770231500279.png" group-title="pluto",Qello Concerts
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F696998915a0ae9e1b563f0c6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="634f307c7a068e00072c9982" tvg-name="Rawhide" tvg-logo="https://images.pluto.tv/channels/634f307c7a068e00072c9982/colorLogoPNG_1731835685335.png" group-title="pluto",Rawhide
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F634f307c7a068e00072c9982?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6549316d2c1d330008631496" tvg-name="Real Housewives Vault" tvg-logo="https://images.pluto.tv/channels/6549316d2c1d330008631496/colorLogoPNG.png" group-title="pluto",Real Housewives Vault
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6549316d2c1d330008631496?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="674f735a2fb8a100087bf253" tvg-name="Revry" tvg-logo="https://images.pluto.tv/channels/674f735a2fb8a100087bf253/colorLogoPNG_1748892659343.png" group-title="pluto",Revry
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F674f735a2fb8a100087bf253?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6996296087742204bff43147" tvg-name="Ridiculousness" tvg-logo="https://images.pluto.tv/channels/6996296087742204bff43147/colorLogoPNG_1772645176417.png" group-title="pluto",Ridiculousness
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6996296087742204bff43147?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="58d947b9e420d8656ee101ab" tvg-name="RiffTrax" tvg-logo="https://images.pluto.tv/channels/58d947b9e420d8656ee101ab/colorLogoPNG.png" group-title="pluto",RiffTrax
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F58d947b9e420d8656ee101ab?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6565430c9d5ac4000822f508" tvg-name="Rustic Retreats" tvg-logo="https://images.pluto.tv/channels/6565430c9d5ac4000822f508/colorLogoPNG.png" group-title="pluto",Rustic Retreats
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6565430c9d5ac4000822f508?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5fb584b7613a31000789de5a" tvg-name="Ryan and Friends" tvg-logo="https://images.pluto.tv/channels/5fb584b7613a31000789de5a/colorLogoPNG.png" group-title="pluto",Ryan and Friends
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5fb584b7613a31000789de5a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="637e55347427a40007fac703" tvg-name="Sailor Moon" tvg-logo="https://images.pluto.tv/channels/637e55347427a40007fac703/colorLogoPNG.png" group-title="pluto",Sailor Moon
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F637e55347427a40007fac703?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66ba53cda4ee2700083fac09" tvg-name="Sala de Emergencias: Historias Inéditas" tvg-logo="https://images.pluto.tv/channels/66ba53cda4ee2700083fac09/colorLogoPNG.png" group-title="pluto",Sala de Emergencias: Historias Inéditas
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66ba53cda4ee2700083fac09?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66a7f0a78561260008c177f2" tvg-name="Salem News Channel" tvg-logo="https://images.pluto.tv/channels/66a7f0a78561260008c177f2/colorLogoPNG.png" group-title="pluto",Salem News Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66a7f0a78561260008c177f2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5459795fc9f133a519bc0bef" tvg-name="Scripps News" tvg-logo="https://images.pluto.tv/channels/5459795fc9f133a519bc0bef/colorLogoPNG.png" group-title="pluto",Scripps News
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5459795fc9f133a519bc0bef?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68ee9a999938143525bfc385" tvg-name="Shop LC" tvg-logo="https://images.pluto.tv/channels/68ee9a999938143525bfc385/colorLogoPNG_1760999630595.png" group-title="pluto",Shop LC
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68ee9a999938143525bfc385?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="633354b63df9700007f6a1b7" tvg-name="Sitcom Legends" tvg-logo="https://images.pluto.tv/channels/633354b63df9700007f6a1b7/colorLogoPNG.png" group-title="pluto",Sitcom Legends
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F633354b63df9700007f6a1b7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="67882c1c7b11714b795c2008" tvg-name="Sketchy AF" tvg-logo="https://images.pluto.tv/channels/67882c1c7b11714b795c2008/colorLogoPNG.png" group-title="pluto",Sketchy AF
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F67882c1c7b11714b795c2008?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="55b285cd2665de274553d66f" tvg-name="Sky News" tvg-logo="https://images.pluto.tv/channels/55b285cd2665de274553d66f/colorLogoPNG.png" group-title="pluto",Sky News
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F55b285cd2665de274553d66f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f21ea08007a49000762d349" tvg-name="Smithsonian Channel Selects" tvg-logo="https://images.pluto.tv/channels/5f21ea08007a49000762d349/colorLogoPNG.png" group-title="pluto",Smithsonian Channel Selects
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f21ea08007a49000762d349?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5c393cad2de254456f7ef8c2" tvg-name="Spike Outdoors" tvg-logo="https://images.pluto.tv/channels/5c393cad2de254456f7ef8c2/colorLogoPNG.png" group-title="pluto",Spike Outdoors
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5c393cad2de254456f7ef8c2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5812bcc8237a6ff45d16c407" tvg-name="Spike Pluto TV" tvg-logo="https://images.pluto.tv/channels/5812bcc8237a6ff45d16c407/colorLogoPNG.png" group-title="pluto",Spike Pluto TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5812bcc8237a6ff45d16c407?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5efbd39f8c4ce900075d7698" tvg-name="Star Trek" tvg-logo="https://images.pluto.tv/channels/5efbd39f8c4ce900075d7698/colorLogoPNG.png" group-title="pluto",Star Trek
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5efbd39f8c4ce900075d7698?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65c69bbfd77d450008c7ffee" tvg-name="Star Trek: Deep Space Nine" tvg-logo="https://images.pluto.tv/channels/65c69bbfd77d450008c7ffee/colorLogoPNG_1758310416057.png" group-title="pluto",Star Trek: Deep Space Nine
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65c69bbfd77d450008c7ffee?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="695c32e61ca20bb8ca802eb9" tvg-name="Star Trek: The Next Generation" tvg-logo="https://images.pluto.tv/channels/695c32e61ca20bb8ca802eb9/colorLogoPNG_1768440087394.png" group-title="pluto",Star Trek: The Next Generation
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F695c32e61ca20bb8ca802eb9?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="634dacf51d90320007fcd5fa" tvg-name="Star Trek: Voyager" tvg-logo="https://images.pluto.tv/channels/634dacf51d90320007fcd5fa/colorLogoPNG_1758310287876.png" group-title="pluto",Star Trek: Voyager
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F634dacf51d90320007fcd5fa?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="620bfa7df72827000703ddb1" tvg-name="Stargate" tvg-logo="https://images.pluto.tv/channels/620bfa7df72827000703ddb1/colorLogoPNG.png" group-title="pluto",Stargate
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F620bfa7df72827000703ddb1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="696689d13b9ce349c9be3a18" tvg-name="Stingray DJAZZ" tvg-logo="https://images.pluto.tv/channels/696689d13b9ce349c9be3a18/colorLogoPNG_1771027556714.png" group-title="pluto",Stingray DJAZZ
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F696689d13b9ce349c9be3a18?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66ff1d5a565d3a000892bdcd" tvg-name="Stingray Holidayscapes" tvg-logo="https://images.pluto.tv/channels/66ff1d5a565d3a000892bdcd/colorLogoPNG_1783464909269.png" group-title="pluto",Stingray Holidayscapes
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66ff1d5a565d3a000892bdcd?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6887aaf4e3703b7d42b71a1e" tvg-name="Storage Wars by A&E" tvg-logo="https://images.pluto.tv/channels/6887aaf4e3703b7d42b71a1e/colorLogoPNG_1755034317630.png" group-title="pluto",Storage Wars by A&E
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6887aaf4e3703b7d42b71a1e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="667f393836a2f90008fd17c0" tvg-name="Strawberry Shortcake and Friends" tvg-logo="https://images.pluto.tv/channels/667f393836a2f90008fd17c0/colorLogoPNG_1753982261322.png" group-title="pluto",Strawberry Shortcake and Friends
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F667f393836a2f90008fd17c0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="649ddbfb6f29ec000874ca9e" tvg-name="Supermarket Sweep" tvg-logo="https://images.pluto.tv/channels/649ddbfb6f29ec000874ca9e/colorLogoPNG.png" group-title="pluto",Supermarket Sweep
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F649ddbfb6f29ec000874ca9e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f24662bebe0f0000767de32" tvg-name="Supernatural Drama" tvg-logo="https://images.pluto.tv/channels/5f24662bebe0f0000767de32/colorLogoPNG.png" group-title="pluto",Supernatural Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f24662bebe0f0000767de32?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f21e7b24744c60007c1f6fc" tvg-name="Survivor" tvg-logo="https://images.pluto.tv/channels/5f21e7b24744c60007c1f6fc/colorLogoPNG.png" group-title="pluto",Survivor
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f21e7b24744c60007c1f6fc?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="683df56f5195c2a60a3f5559" tvg-name="Swerve Women’s Sports" tvg-logo="https://images.pluto.tv/channels/683df56f5195c2a60a3f5559/colorLogoPNG_1775667541424.png" group-title="pluto",Swerve Women’s Sports
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F683df56f5195c2a60a3f5559?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="59b722526996084038c01e1b" tvg-name="TNA Wrestling" tvg-logo="https://images.pluto.tv/channels/59b722526996084038c01e1b/colorLogoPNG.png" group-title="pluto",TNA Wrestling
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F59b722526996084038c01e1b?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d695f7db53adf96b78e7ce3" tvg-name="TODAY All Day" tvg-logo="https://images.pluto.tv/channels/5d695f7db53adf96b78e7ce3/colorLogoPNG.png" group-title="pluto",TODAY All Day
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d695f7db53adf96b78e7ce3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d0c16d686454ead733d08f8" tvg-name="TOTALLY TURTLES" tvg-logo="https://images.pluto.tv/channels/5d0c16d686454ead733d08f8/colorLogoPNG.png" group-title="pluto",TOTALLY TURTLES
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d0c16d686454ead733d08f8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d40bebc5e3d2750a2239d7e" tvg-name="TV Land Drama" tvg-logo="https://images.pluto.tv/channels/5d40bebc5e3d2750a2239d7e/colorLogoPNG.png" group-title="pluto",TV Land Drama
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d40bebc5e3d2750a2239d7e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5c2d64ffbdf11b71587184b8" tvg-name="TV Land Sitcoms" tvg-logo="https://images.pluto.tv/channels/5c2d64ffbdf11b71587184b8/colorLogoPNG.png" group-title="pluto",TV Land Sitcoms
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5c2d64ffbdf11b71587184b8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68509fe882d704acfc5bacd1" tvg-name="Tastemade Smokehouse" tvg-logo="https://images.pluto.tv/channels/68509fe882d704acfc5bacd1/colorLogoPNG_1750914005853.png" group-title="pluto",Tastemade Smokehouse
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68509fe882d704acfc5bacd1?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6127e12ed140e900077e7b6f" tvg-name="Teen Mom" tvg-logo="https://images.pluto.tv/channels/6127e12ed140e900077e7b6f/colorLogoPNG.png" group-title="pluto",Teen Mom
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6127e12ed140e900077e7b6f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5cf96cc422df39f1a338d165" tvg-name="Telemundo telenovelas clásicas" tvg-logo="https://images.pluto.tv/channels/5cf96cc422df39f1a338d165/colorLogoPNG.png" group-title="pluto",Telemundo telenovelas clásicas
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5cf96cc422df39f1a338d165?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="681109b688b9d85d0938c6ba" tvg-name="TennisChannel 2" tvg-logo="https://images.pluto.tv/channels/681109b688b9d85d0938c6ba/colorLogoPNG_1747434868944.png" group-title="pluto",TennisChannel 2
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F681109b688b9d85d0938c6ba?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d81607ab737153ea3c1c80e" tvg-name="The Addams Family" tvg-logo="https://images.pluto.tv/channels/5d81607ab737153ea3c1c80e/colorLogoPNG.png" group-title="pluto",The Addams Family
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d81607ab737153ea3c1c80e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f21e8a6e2f12b000755afdb" tvg-name="The Amazing Race" tvg-logo="https://images.pluto.tv/channels/5f21e8a6e2f12b000755afdb/colorLogoPNG.png" group-title="pluto",The Amazing Race
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f21e8a6e2f12b000755afdb?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60f75178e7f8aa0007e9c259" tvg-name="The Andy Griffith Show" tvg-logo="https://images.pluto.tv/channels/60f75178e7f8aa0007e9c259/colorLogoPNG_1758310637593.png" group-title="pluto",The Andy Griffith Show
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60f75178e7f8aa0007e9c259?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f36d726234ce10007784f2a" tvg-name="The Bob Ross Channel" tvg-logo="https://images.pluto.tv/channels/5f36d726234ce10007784f2a/colorLogoPNG.png" group-title="pluto",The Bob Ross Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f36d726234ce10007784f2a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d48685da7e9f476aa8a1888" tvg-name="The Challenge" tvg-logo="https://images.pluto.tv/channels/5d48685da7e9f476aa8a1888/colorLogoPNG.png" group-title="pluto",The Challenge
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d48685da7e9f476aa8a1888?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d486acc34ceb37d3c458a64" tvg-name="The First" tvg-logo="https://images.pluto.tv/channels/5d486acc34ceb37d3c458a64/colorLogoPNG.png" group-title="pluto",The First
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d486acc34ceb37d3c458a64?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6887aaade3703b7d42b64be8" tvg-name="The First 48 by A&E" tvg-logo="https://images.pluto.tv/channels/6887aaade3703b7d42b64be8/colorLogoPNG_1754999153420.png" group-title="pluto",The First 48 by A&E
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6887aaade3703b7d42b64be8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64dab9df3d48f40008868091" tvg-name="The Jamie Oliver Channel" tvg-logo="https://images.pluto.tv/channels/64dab9df3d48f40008868091/colorLogoPNG.png" group-title="pluto",The Jamie Oliver Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64dab9df3d48f40008868091?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6283d51144ad8f0007fa382d" tvg-name="The Judge Judy Channel" tvg-logo="https://images.pluto.tv/channels/6283d51144ad8f0007fa382d/colorLogoPNG.png" group-title="pluto",The Judge Judy Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6283d51144ad8f0007fa382d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65a6dafb7bdc8d0008473c85" tvg-name="The Lone Ranger" tvg-logo="https://images.pluto.tv/channels/65a6dafb7bdc8d0008473c85/colorLogoPNG.png" group-title="pluto",The Lone Ranger
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65a6dafb7bdc8d0008473c85?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f7794a788d29000079d2f07" tvg-name="The Love Boat" tvg-logo="https://images.pluto.tv/channels/5f7794a788d29000079d2f07/colorLogoPNG_1731835231895.png" group-title="pluto",The Love Boat
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f7794a788d29000079d2f07?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="67c62ac2095aea2ec805eb34" tvg-name="The Martha Stewart Channel" tvg-logo="https://images.pluto.tv/channels/67c62ac2095aea2ec805eb34/colorLogoPNG.png" group-title="pluto",The Martha Stewart Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F67c62ac2095aea2ec805eb34?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6792c30abc03978b9b8bb832" tvg-name="The NBA Channel" tvg-logo="https://images.pluto.tv/channels/6792c30abc03978b9b8bb832/colorLogoPNG_1747950897785.png" group-title="pluto",The NBA Channel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6792c30abc03978b9b8bb832?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5aea40b35126c2157123aa64" tvg-name="The New Detectives" tvg-logo="https://images.pluto.tv/channels/5aea40b35126c2157123aa64/colorLogoPNG.png" group-title="pluto",The New Detectives
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5aea40b35126c2157123aa64?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5bb1ad55268cae539bcedb08" tvg-name="The Pet Collective" tvg-logo="https://images.pluto.tv/channels/5bb1ad55268cae539bcedb08/colorLogoPNG.png" group-title="pluto",The Pet Collective
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5bb1ad55268cae539bcedb08?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="643f035d5a0cd50008361534" tvg-name="The Price Is Right" tvg-logo="https://images.pluto.tv/channels/643f035d5a0cd50008361534/colorLogoPNG.png" group-title="pluto",The Price Is Right
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F643f035d5a0cd50008361534?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f7791b8372da90007fd45e6" tvg-name="The Price Is Right: The Barker Era" tvg-logo="https://images.pluto.tv/channels/5f7791b8372da90007fd45e6/colorLogoPNG.png" group-title="pluto",The Price Is Right: The Barker Era
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f7791b8372da90007fd45e6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e825550e758c700077b0aef" tvg-name="The Rifleman" tvg-logo="https://images.pluto.tv/channels/5e825550e758c700077b0aef/colorLogoPNG.png" group-title="pluto",The Rifleman
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e825550e758c700077b0aef?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="67352ed93a61d4000881f9fa" tvg-name="The Twilight Zone" tvg-logo="https://images.pluto.tv/channels/67352ed93a61d4000881f9fa/colorLogoPNG_1732662672508.png" group-title="pluto",The Twilight Zone
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F67352ed93a61d4000881f9fa?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="62fa8176b9884200074ef5ae" tvg-name="The Walking Dead Universe" tvg-logo="https://images.pluto.tv/channels/62fa8176b9884200074ef5ae/colorLogoPNG.png" group-title="pluto",The Walking Dead Universe
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F62fa8176b9884200074ef5ae?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e82bb378601b80007b4bd78" tvg-name="The Walking Dead en español" tvg-logo="https://images.pluto.tv/channels/5e82bb378601b80007b4bd78/colorLogoPNG.png" group-title="pluto",The Walking Dead en español
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e82bb378601b80007b4bd78?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="664e640a0120f40008be4582" tvg-name="The Wild Wild West" tvg-logo="https://images.pluto.tv/channels/664e640a0120f40008be4582/colorLogoPNG.png" group-title="pluto",The Wild Wild West
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F664e640a0120f40008be4582?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6913e381b6bf26bb6e798c13" tvg-name="The X-Files" tvg-logo="https://images.pluto.tv/channels/6913e381b6bf26bb6e798c13/colorLogoPNG_1767310653556.png" group-title="pluto",The X-Files
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6913e381b6bf26bb6e798c13?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d51e791b7dba3b2ae990ab2" tvg-name="This Old House" tvg-logo="https://images.pluto.tv/channels/5d51e791b7dba3b2ae990ab2/colorLogoPNG.png" group-title="pluto",This Old House
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d51e791b7dba3b2ae990ab2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5ef3977e5d773400077de284" tvg-name="Three's Company" tvg-logo="https://images.pluto.tv/channels/5ef3977e5d773400077de284/colorLogoPNG_1731835807101.png" group-title="pluto",Three's Company
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5ef3977e5d773400077de284?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69445a9a78c0c45b6c9aa8b9" tvg-name="TikTok Radio" tvg-logo="https://images.pluto.tv/channels/69445a9a78c0c45b6c9aa8b9/colorLogoPNG_1771261855448.png" group-title="pluto",TikTok Radio
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69445a9a78c0c45b6c9aa8b9?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="601a0342dcf4370007566891" tvg-name="Tiny House Nation" tvg-logo="https://images.pluto.tv/channels/601a0342dcf4370007566891/colorLogoPNG_1775171305009.png" group-title="pluto",Tiny House Nation
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F601a0342dcf4370007566891?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="68757effdf333e336be1e49f" tvg-name="Tony Robbins Network" tvg-logo="https://images.pluto.tv/channels/68757effdf333e336be1e49f/colorLogoPNG_1754963877109.png" group-title="pluto",Tony Robbins Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F68757effdf333e336be1e49f?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="636adc255bcf470007d6e0e2" tvg-name="Top Gear" tvg-logo="https://images.pluto.tv/channels/636adc255bcf470007d6e0e2/colorLogoPNG.png" group-title="pluto",Top Gear
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F636adc255bcf470007d6e0e2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64d160f53c785e0008df525e" tvg-name="Top Rank Classics" tvg-logo="https://images.pluto.tv/channels/64d160f53c785e0008df525e/colorLogoPNG.png" group-title="pluto",Top Rank Classics
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64d160f53c785e0008df525e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5dae084727c8af0009fe40a4" tvg-name="Tosh.0" tvg-logo="https://images.pluto.tv/channels/5dae084727c8af0009fe40a4/colorLogoPNG_1731837283801.png" group-title="pluto",Tosh.0
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5dae084727c8af0009fe40a4?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6a2b0edf201df02a8bfea30a" tvg-name="Touched By An Angel" tvg-logo="https://images.pluto.tv/channels/6a2b0edf201df02a8bfea30a/colorLogoPNG_1782947651184.png" group-title="pluto",Touched By An Angel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6a2b0edf201df02a8bfea30a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65c69bf23ef47d0008583967" tvg-name="Tough Jobs" tvg-logo="https://images.pluto.tv/channels/65c69bf23ef47d0008583967/colorLogoPNG.png" group-title="pluto",Tough Jobs
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65c69bf23ef47d0008583967?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="60fb053712f22a0007ff14d2" tvg-name="Transformers TV" tvg-logo="https://images.pluto.tv/channels/60fb053712f22a0007ff14d2/colorLogoPNG.png" group-title="pluto",Transformers TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F60fb053712f22a0007ff14d2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65ea8b928145cb0008509426" tvg-name="UEFA Champions League" tvg-logo="https://images.pluto.tv/channels/65ea8b928145cb0008509426/colorLogoPNG.png" group-title="pluto",UEFA Champions League
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65ea8b928145cb0008509426?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="677d9adfa9a51b0008497fa0" tvg-name="UFC" tvg-logo="https://images.pluto.tv/channels/677d9adfa9a51b0008497fa0/colorLogoPNG.png" group-title="pluto",UFC
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F677d9adfa9a51b0008497fa0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="656542ae4261ca00082154a8" tvg-name="Ultimate Builds" tvg-logo="https://images.pluto.tv/channels/656542ae4261ca00082154a8/colorLogoPNG.png" group-title="pluto",Ultimate Builds
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F656542ae4261ca00082154a8?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="656538f8954b020008d389db" tvg-name="UnXplained Zone" tvg-logo="https://images.pluto.tv/channels/656538f8954b020008d389db/colorLogoPNG_1767736227039.png" group-title="pluto",UnXplained Zone
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F656538f8954b020008d389db?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="654933e253fc970008390114" tvg-name="Universal Action" tvg-logo="https://images.pluto.tv/channels/654933e253fc970008390114/colorLogoPNG.png" group-title="pluto",Universal Action
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F654933e253fc970008390114?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6549341853fc9700083901ac" tvg-name="Universal Crime" tvg-logo="https://images.pluto.tv/channels/6549341853fc9700083901ac/colorLogoPNG.png" group-title="pluto",Universal Crime
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6549341853fc9700083901ac?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="65a9b20f0c7ff50008d3a3b6" tvg-name="Universal Monsters" tvg-logo="https://images.pluto.tv/channels/65a9b20f0c7ff50008d3a3b6/colorLogoPNG.png" group-title="pluto",Universal Monsters
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F65a9b20f0c7ff50008d3a3b6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5b4e96a0423e067bd6df6901" tvg-name="Unsolved Mysteries" tvg-logo="https://images.pluto.tv/channels/5b4e96a0423e067bd6df6901/colorLogoPNG.png" group-title="pluto",Unsolved Mysteries
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5b4e96a0423e067bd6df6901?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="66abefe5d2d50d00082c7d12" tvg-name="VH1 Queens of Reality" tvg-logo="https://images.pluto.tv/channels/66abefe5d2d50d00082c7d12/colorLogoPNG.png" group-title="pluto",VH1 Queens of Reality
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F66abefe5d2d50d00082c7d12?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f32f26bcd8aea00071240e5" tvg-name="Vevo '70s" tvg-logo="https://images.pluto.tv/channels/5f32f26bcd8aea00071240e5/colorLogoPNG.png" group-title="pluto",Vevo '70s
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f32f26bcd8aea00071240e5?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5fd7b8bf927e090007685853" tvg-name="Vevo '80s" tvg-logo="https://images.pluto.tv/channels/5fd7b8bf927e090007685853/colorLogoPNG.png" group-title="pluto",Vevo '80s
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5fd7b8bf927e090007685853?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5fd7bb1f86d94a000796e2c2" tvg-name="Vevo '90s" tvg-logo="https://images.pluto.tv/channels/5fd7bb1f86d94a000796e2c2/colorLogoPNG.png" group-title="pluto",Vevo '90s
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5fd7bb1f86d94a000796e2c2?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5fd7bca3e0a4ee0007a38e8c" tvg-name="Vevo 2K" tvg-logo="https://images.pluto.tv/channels/5fd7bca3e0a4ee0007a38e8c/colorLogoPNG.png" group-title="pluto",Vevo 2K
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5fd7bca3e0a4ee0007a38e8c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5da0d75e84830900098a1ea0" tvg-name="Vevo Country" tvg-logo="https://images.pluto.tv/channels/5da0d75e84830900098a1ea0/colorLogoPNG.png" group-title="pluto",Vevo Country
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5da0d75e84830900098a1ea0?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6334a3ffdc283500076acf92" tvg-name="Vevo Holiday" tvg-logo="https://images.pluto.tv/channels/6334a3ffdc283500076acf92/colorLogoPNG_1762031770975.png" group-title="pluto",Vevo Holiday
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6334a3ffdc283500076acf92?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d93b635b43dd1a399b39eee" tvg-name="Vevo Pop" tvg-logo="https://images.pluto.tv/channels/5d93b635b43dd1a399b39eee/colorLogoPNG.png" group-title="pluto",Vevo Pop
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d93b635b43dd1a399b39eee?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5da0d83f66c9700009b96d0e" tvg-name="Vevo R&B" tvg-logo="https://images.pluto.tv/channels/5da0d83f66c9700009b96d0e/colorLogoPNG.png" group-title="pluto",Vevo R&B
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5da0d83f66c9700009b96d0e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64dab5fe35425100080e2991" tvg-name="Vevo Regional Mexicano" tvg-logo="https://images.pluto.tv/channels/64dab5fe35425100080e2991/colorLogoPNG.png" group-title="pluto",Vevo Regional Mexicano
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64dab5fe35425100080e2991?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="61d4b38226b8a50007fe03a6" tvg-name="Vevo Rock" tvg-logo="https://images.pluto.tv/channels/61d4b38226b8a50007fe03a6/colorLogoPNG_1748797615724.png" group-title="pluto",Vevo Rock
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F61d4b38226b8a50007fe03a6?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="61d4c2817a823d00070ba53e" tvg-name="Vevo True School Hip-Hop" tvg-logo="https://images.pluto.tv/channels/61d4c2817a823d00070ba53e/colorLogoPNG.png" group-title="pluto",Vevo True School Hip-Hop
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F61d4c2817a823d00070ba53e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="64d161c93c785e0008df575e" tvg-name="Vevo Íconos Latinos" tvg-logo="https://images.pluto.tv/channels/64d161c93c785e0008df575e/colorLogoPNG.png" group-title="pluto",Vevo Íconos Latinos
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F64d161c93c785e0008df575e?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="673249afc7626f0008c7205d" tvg-name="Vidas Extremas" tvg-logo="https://images.pluto.tv/channels/673249afc7626f0008c7205d/colorLogoPNG.png" group-title="pluto",Vidas Extremas
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F673249afc7626f0008c7205d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="632b6233822bbc000748fd81" tvg-name="WFTV Orlando" tvg-logo="https://images.pluto.tv/channels/632b6233822bbc000748fd81/colorLogoPNG.png" group-title="pluto",WFTV Orlando
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F632b6233822bbc000748fd81?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="632b642933a6280007aaf265" tvg-name="WSB Atlanta" tvg-logo="https://images.pluto.tv/channels/632b642933a6280007aaf265/colorLogoPNG.png" group-title="pluto",WSB Atlanta
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F632b642933a6280007aaf265?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="632b648c08cd050007d94114" tvg-name="WSOC Charlotte" tvg-logo="https://images.pluto.tv/channels/632b648c08cd050007d94114/colorLogoPNG.png" group-title="pluto",WSOC Charlotte
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F632b648c08cd050007d94114?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6532e8342cf13100083b404c" tvg-name="Warner Bros. TV Say Yes to the Dress" tvg-logo="https://images.pluto.tv/channels/6532e8342cf13100083b404c/colorLogoPNG.png" group-title="pluto",Warner Bros. TV Say Yes to the Dress
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6532e8342cf13100083b404c?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6532e7fa045c3d0008514ca7" tvg-name="Warner Bros. TV Sweet Escapes" tvg-logo="https://images.pluto.tv/channels/6532e7fa045c3d0008514ca7/colorLogoPNG.png" group-title="pluto",Warner Bros. TV Sweet Escapes
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6532e7fa045c3d0008514ca7?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="628c20c0097ef20007607938" tvg-name="WeatherNation Charlotte" tvg-logo="https://images.pluto.tv/channels/628c20c0097ef20007607938/colorLogoPNG.png" group-title="pluto",WeatherNation Charlotte
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F628c20c0097ef20007607938?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5e8df4bc16e34700077e77d3" tvg-name="Western TV" tvg-logo="https://images.pluto.tv/channels/5e8df4bc16e34700077e77d3/colorLogoPNG.png" group-title="pluto",Western TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5e8df4bc16e34700077e77d3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="686c2677ed17cf4c900a496d" tvg-name="Wicked Tuna" tvg-logo="https://images.pluto.tv/channels/686c2677ed17cf4c900a496d/colorLogoPNG_1755124512679.png" group-title="pluto",Wicked Tuna
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F686c2677ed17cf4c900a496d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d48678d34ceb37d3c458a55" tvg-name="Wild 'N Out" tvg-logo="https://images.pluto.tv/channels/5d48678d34ceb37d3c458a55/colorLogoPNG.png" group-title="pluto",Wild 'N Out
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d48678d34ceb37d3c458a55?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="686d8dd294a028da3ac59566" tvg-name="Women's Sports Network" tvg-logo="https://images.pluto.tv/channels/686d8dd294a028da3ac59566/colorLogoPNG_1753992941899.png" group-title="pluto",Women's Sports Network
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F686d8dd294a028da3ac59566?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5616f9c0ada51f8004c4b091" tvg-name="World Poker Tour" tvg-logo="https://images.pluto.tv/channels/5616f9c0ada51f8004c4b091/colorLogoPNG-1664295222280.png" group-title="pluto",World Poker Tour
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5616f9c0ada51f8004c4b091?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="69699b6d23ea437206f4a036" tvg-name="World of Love Island" tvg-logo="https://images.pluto.tv/channels/69699b6d23ea437206f4a036/colorLogoPNG_1770050839989.png" group-title="pluto",World of Love Island
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F69699b6d23ea437206f4a036?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="623b92a2ccefed0007b1db48" tvg-name="XITE Classic Country" tvg-logo="https://images.pluto.tv/channels/623b92a2ccefed0007b1db48/colorLogoPNG.png" group-title="pluto",XITE Classic Country
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F623b92a2ccefed0007b1db48?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="623b93628e6ded0007337d4d" tvg-name="XITE Gospel" tvg-logo="https://images.pluto.tv/channels/623b93628e6ded0007337d4d/colorLogoPNG.png" group-title="pluto",XITE Gospel
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F623b93628e6ded0007337d4d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="623a1b5188ecdc0007c9ef5a" tvg-name="XITE Rock x Metal" tvg-logo="https://images.pluto.tv/channels/623a1b5188ecdc0007c9ef5a/colorLogoPNG.png" group-title="pluto",XITE Rock x Metal
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F623a1b5188ecdc0007c9ef5a?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6000a6f4c3f8550008fc9b91" tvg-name="Xtreme Outdoor by HISTORY" tvg-logo="https://images.pluto.tv/channels/6000a6f4c3f8550008fc9b91/colorLogoPNG_1767745185882.png" group-title="pluto",Xtreme Outdoor by HISTORY
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6000a6f4c3f8550008fc9b91?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5d14fc31252d35decbc4080b" tvg-name="Yo! MTV" tvg-logo="https://images.pluto.tv/channels/5d14fc31252d35decbc4080b/colorLogoPNG.png" group-title="pluto",Yo! MTV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5d14fc31252d35decbc4080b?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="5f4ec10ed9636f00089b8c89" tvg-name="Yu-Gi-Oh!" tvg-logo="https://images.pluto.tv/channels/5f4ec10ed9636f00089b8c89/colorLogoPNG.png" group-title="pluto",Yu-Gi-Oh!
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F5f4ec10ed9636f00089b8c89?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="696998dfa2b623e8b20125a3" tvg-name="ZenLIFE by Stingray" tvg-logo="https://images.pluto.tv/channels/696998dfa2b623e8b20125a3/colorLogoPNG_1770231337178.png" group-title="pluto",ZenLIFE by Stingray
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F696998dfa2b623e8b20125a3?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto
+#EXTINF:-1 tvg-id="6450209d939a5900084dba1d" tvg-name="iCarly TV" tvg-logo="https://images.pluto.tv/channels/6450209d939a5900084dba1d/colorLogoPNG.png" group-title="pluto",iCarly TV
+http://localhost:3000/api/ext/v1/pluto/pluto%3A%2F%2Fus_east%2F6450209d939a5900084dba1d?token=1f3e916c43f6abb9a0400f72350062ef&pl=pluto

--- a/proxy/src/manifest.rs
+++ b/proxy/src/manifest.rs
@@ -11,6 +11,7 @@
 //! except for its URIs — unknown tags, comments, and ordering pass through untouched.
 
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use std::borrow::Cow;
 use url::Url;
 
 /// Decode metadata declared IN the manifest — parsed WITHOUT ffprobe (the video-engine teardown removed it).
@@ -168,6 +169,105 @@ pub fn rewrite_manifest(body: &str, base: &Url, prefix: &str, suffix: &str) -> R
     }
 }
 
+/// STREAM-INF Redux (SIR) — an OPT-IN, non-destructive reorder of an already-rewritten MASTER playlist so the
+/// first `#EXT-X-STREAM-INF` lands within the small window a strict player peeks to sniff content-type (VLC's
+/// fixed ~8 KiB probe; ffmpeg's `hls_probe` `strstr`s for the same literal). Because `rewrite_manifest` only
+/// ever LENGTHENS URIs and never reorders, a master whose `#EXT-X-MEDIA` rendition block precedes the variants
+/// can push the first STREAM-INF past that window, and the client fails to recognize the response as HLS.
+///
+/// This hoists the STREAM-INF variant blocks ABOVE the `#EXT-X-MEDIA`/session block WITHOUT dropping any variant
+/// or rendition. Reordering is spec-legal (RFC 8216: only `#EXTM3U` is position-pinned; variant↔rendition
+/// association is by GROUP-ID, position-independent) and every current player (ffmpeg/hls.js/VLC) associates
+/// renditions after a full parse. proxy.rs applies it ONLY on the external-player mount when the
+/// (Default)/(Custom) proxy-config `streamInfRedux` flag is on — a pure post-transform layered OVER
+/// `rewrite_manifest` (which is unchanged), so the delivery path is byte-identical when the flag is off. A
+/// non-master (no STREAM-INF) is returned borrowed/unchanged — the common media-playlist poll never allocates.
+pub fn redux_master(body: &str) -> Cow<'_, str> {
+    // Fast path: not a master (media playlist / non-HLS / I-frame-only) → byte-identical, no allocation. Uses
+    // the same `#EXT-X-STREAM-INF:` (with colon) detection as extract_media, so #EXT-X-I-FRAME-STREAM-INF alone
+    // is NOT treated as a master (there is nothing to hoist, and probes key on the regular literal).
+    if !body.split('\n').any(|l| l.trim().starts_with("#EXT-X-STREAM-INF:")) {
+        return Cow::Borrowed(body);
+    }
+
+    let preserve_trailing_newline = body.ends_with('\n');
+
+    // Four ordered buckets; within-bucket input order is preserved (so default-variant selection is unchanged).
+    let mut lead: Vec<&str> = Vec::new(); // #EXTM3U + declarations that must stay near the top
+    let mut variants: Vec<String> = Vec::new(); // #EXT-X-STREAM-INF + its URI line (kept together as one unit)
+    let mut iframes: Vec<&str> = Vec::new(); // #EXT-X-I-FRAME-STREAM-INF (self-contained line; URI is an attr)
+    let mut tail: Vec<&str> = Vec::new(); // #EXT-X-MEDIA / session tags / unknown #EXT-X-* / comments / stray URIs
+
+    // rewrite_manifest already normalized to LF; strip a trailing \r defensively so direct/test callers are safe.
+    let lines: Vec<&str> = body.split('\n').map(|l| l.strip_suffix('\r').unwrap_or(l)).collect();
+
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            i += 1; // drop pure-blank lines (the only lines removed)
+            continue;
+        }
+        if trimmed.starts_with("#EXT-X-STREAM-INF:") {
+            // Pair with the next NON-BLANK, NON-`#` line (the variant URI — matches tsmux::pick_variant).
+            let mut j = i + 1;
+            while j < lines.len() && lines[j].trim().is_empty() {
+                j += 1;
+            }
+            if j < lines.len() && !lines[j].trim().starts_with('#') {
+                variants.push(format!("{}\n{}", line, lines[j]));
+                i = j + 1;
+            } else {
+                // Unpaired (next non-blank is a tag, or EOF) — emit the STREAM-INF alone; never swallow a `#` line.
+                variants.push(line.to_string());
+                i += 1;
+            }
+            continue;
+        }
+        if trimmed.starts_with("#EXT-X-I-FRAME-STREAM-INF") {
+            iframes.push(line); // single line — do NOT consume the next line
+            i += 1;
+            continue;
+        }
+        if trimmed.starts_with("#EXTM3U")
+            || trimmed.starts_with("#EXT-X-VERSION")
+            || trimmed.starts_with("#EXT-X-INDEPENDENT-SEGMENTS")
+            || trimmed.starts_with("#EXT-X-DEFINE") // variables must be defined BEFORE first use
+            || trimmed.starts_with("#EXT-X-START")
+        {
+            lead.push(line);
+            i += 1;
+            continue;
+        }
+        // Renditions, session tags, unknown #EXT-X-*, bare comments, stray bare URIs → tail (preserved, never
+        // pushed into the probe window). This is the SAFE default: nothing is dropped except blank lines.
+        tail.push(line);
+        i += 1;
+    }
+
+    // #EXTM3U must be absolute line 1 (RFC 8216 §4.3.1.1). If present out of place, force it to the front.
+    if let Some(pos) = lead.iter().position(|l| l.trim().starts_with("#EXTM3U")) {
+        if pos != 0 {
+            let m = lead.remove(pos);
+            lead.insert(0, m);
+        }
+    }
+
+    // Re-emit: lead → variants → iframes → tail.
+    let mut out: Vec<String> = Vec::with_capacity(lead.len() + variants.len() + iframes.len() + tail.len());
+    out.extend(lead.into_iter().map(str::to_string));
+    out.append(&mut variants);
+    out.extend(iframes.into_iter().map(str::to_string));
+    out.extend(tail.into_iter().map(str::to_string));
+
+    let mut joined = out.join("\n");
+    if preserve_trailing_newline {
+        joined.push('\n');
+    }
+    Cow::Owned(joined)
+}
+
 /// Find an attribute value by (case-sensitive) key, treating an empty value as absent.
 fn attr<'a>(attrs: &'a [(String, String)], key: &str) -> Option<&'a str> {
     attrs
@@ -297,5 +397,178 @@ mod tests {
         assert_eq!(r.media.container.as_deref(), Some("fmp4"));
         // The init-segment URI is still rewritten through the proxy (else the player fetches it direct).
         assert!(r.body.contains("URI=\"/p/https%3A%2F%2Fcdn.example.com%2Flive%2Finit.mp4\""));
+    }
+
+    // ── STREAM-INF Redux (redux_master) ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn redux_not_a_master_passthrough() {
+        // A media playlist (no STREAM-INF) is returned byte-identical AND borrowed (no alloc on the hot path).
+        let m = "#EXTM3U\n#EXT-X-TARGETDURATION:6\n#EXTINF:6.0,\nseg1.ts\n";
+        let r = redux_master(m);
+        assert!(matches!(r, Cow::Borrowed(_)));
+        assert_eq!(r, m);
+    }
+
+    #[test]
+    fn redux_hoists_stream_inf_before_media() {
+        let m = "#EXTM3U\n\
+                 #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"a\",NAME=\"en\",URI=\"a.m3u8\"\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=1,AUDIO=\"a\"\n\
+                 v.m3u8\n";
+        let out = redux_master(m).into_owned();
+        let si = out.find("#EXT-X-STREAM-INF").unwrap();
+        let med = out.find("#EXT-X-MEDIA").unwrap();
+        assert!(si < med, "STREAM-INF must precede MEDIA after redux:\n{out}");
+    }
+
+    #[test]
+    fn redux_first_stream_inf_within_peek_window() {
+        // Regression for the real bug shape: many long rendition lines BEFORE the variants push the first
+        // STREAM-INF past VLC's 8192-byte probe window. After redux it must sit near the top.
+        let mut m = String::from("#EXTM3U\n#EXT-X-VERSION:6\n#EXT-X-INDEPENDENT-SEGMENTS\n");
+        let long = "x".repeat(360);
+        for i in 0..30 {
+            m.push_str(&format!(
+                "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"g{i}\",NAME=\"n{i}\",URI=\"/api/ext/v1/s/h/{long}\"\n"
+            ));
+        }
+        m.push_str("#EXT-X-STREAM-INF:BANDWIDTH=6000000,AUDIO=\"g0\"\nv0.m3u8\n");
+        m.push_str("#EXT-X-STREAM-INF:BANDWIDTH=3000000,AUDIO=\"g0\"\nv1.m3u8\n");
+        // Pre-condition: the bug reproduces (first STREAM-INF is past the window before redux).
+        assert!(m.find("#EXT-X-STREAM-INF").unwrap() > 8192);
+        let out = redux_master(&m).into_owned();
+        assert!(out.find("#EXT-X-STREAM-INF").unwrap() < 1024);
+    }
+
+    #[test]
+    fn redux_pairs_stream_inf_with_correct_uri() {
+        let m = "#EXTM3U\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=6000000\nhigh.m3u8\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=3000000\nlow.m3u8\n";
+        let out = redux_master(m).into_owned();
+        // Each STREAM-INF is immediately followed by ITS OWN URI (no swap).
+        assert!(out.contains("BANDWIDTH=6000000\nhigh.m3u8"));
+        assert!(out.contains("BANDWIDTH=3000000\nlow.m3u8"));
+    }
+
+    #[test]
+    fn redux_preserves_within_group_order() {
+        let m = "#EXTM3U\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=6000000\nhigh.m3u8\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=3000000\nlow.m3u8\n\
+                 #EXT-X-MEDIA:TYPE=AUDIO,NAME=\"first\"\n\
+                 #EXT-X-MEDIA:TYPE=AUDIO,NAME=\"second\"\n";
+        let out = redux_master(m).into_owned();
+        assert!(out.find("high.m3u8").unwrap() < out.find("low.m3u8").unwrap());
+        assert!(out.find("NAME=\"first\"").unwrap() < out.find("NAME=\"second\"").unwrap());
+    }
+
+    #[test]
+    fn redux_iframe_is_single_line_and_after_regular() {
+        let m = "#EXTM3U\n\
+                 #EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=100,URI=\"iframe.m3u8\"\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=6000000\nv.m3u8\n";
+        let out = redux_master(m).into_owned();
+        // Regular STREAM-INF comes before the I-frame variant (probes strstr the literal #EXT-X-STREAM-INF:).
+        assert!(out.find("#EXT-X-STREAM-INF:").unwrap() < out.find("#EXT-X-I-FRAME-STREAM-INF").unwrap());
+        // The I-frame line did not swallow the following line (its URI is an attribute).
+        assert!(out.contains("#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=100,URI=\"iframe.m3u8\""));
+    }
+
+    #[test]
+    fn redux_is_non_destructive() {
+        let m = "#EXTM3U\n\
+                 #EXT-X-MEDIA:TYPE=AUDIO,NAME=\"en\"\n\
+                 #EXT-X-MEDIA:TYPE=SUBTITLES,NAME=\"sub\"\n\
+                 #EXT-X-SESSION-DATA:DATA-ID=\"x\"\n\
+                 #EXT-X-SESSION-KEY:METHOD=AES-128,URI=\"k\"\n\
+                 #EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1,URI=\"if.m3u8\"\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=6000000\nv.m3u8\n";
+        let out = redux_master(m).into_owned();
+        let count = |hay: &str, needle: &str| hay.matches(needle).count();
+        // #EXT-X-I-FRAME-STREAM-INF: does NOT contain the substring #EXT-X-STREAM-INF: — count is exact.
+        assert_eq!(count(&out, "#EXT-X-STREAM-INF:"), 1);
+        assert_eq!(count(&out, "#EXT-X-I-FRAME-STREAM-INF"), 1);
+        assert_eq!(count(&out, "#EXT-X-MEDIA"), 2);
+        assert_eq!(count(&out, "#EXT-X-SESSION-DATA"), 1);
+        assert_eq!(count(&out, "#EXT-X-SESSION-KEY"), 1);
+        assert!(out.contains("v.m3u8"));
+    }
+
+    #[test]
+    fn redux_drops_blank_lines_keeps_comments() {
+        let m = "#EXTM3U\n\n#EXT-X-STREAM-INF:BANDWIDTH=1\nv.m3u8\n\n# operator note\n";
+        let out = redux_master(m).into_owned();
+        assert!(!out.contains("\n\n"), "blank lines should be dropped:\n{out:?}");
+        assert!(out.contains("# operator note"), "bare comments must be preserved (routed to tail)");
+    }
+
+    #[test]
+    fn redux_extm3u_stays_first_line() {
+        // #EXTM3U not first in the input (unusual) is forced back to line 1.
+        let m = "#EXT-X-VERSION:6\n#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nv.m3u8\n";
+        let out = redux_master(m).into_owned();
+        assert!(out.starts_with("#EXTM3U\n"), "output must start with #EXTM3U:\n{out}");
+    }
+
+    #[test]
+    fn redux_hoists_define_before_variants() {
+        // #EXT-X-DEFINE declares variables that must precede any use → it belongs in the lead.
+        let m = "#EXTM3U\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=1\nv.m3u8\n\
+                 #EXT-X-DEFINE:NAME=\"host\",VALUE=\"cdn\"\n";
+        let out = redux_master(m).into_owned();
+        assert!(out.find("#EXT-X-DEFINE").unwrap() < out.find("#EXT-X-STREAM-INF").unwrap());
+    }
+
+    #[test]
+    fn redux_unknown_tag_goes_to_tail() {
+        let m = "#EXTM3U\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=1\nv.m3u8\n\
+                 #EXT-X-FUTURE-TAG:whatever\n";
+        let out = redux_master(m).into_owned();
+        // Preserved, and positioned AFTER the first STREAM-INF (never pushed into the probe window).
+        assert!(out.contains("#EXT-X-FUTURE-TAG:whatever"));
+        assert!(out.find("#EXT-X-STREAM-INF").unwrap() < out.find("#EXT-X-FUTURE-TAG").unwrap());
+    }
+
+    #[test]
+    fn redux_handles_crlf() {
+        let m = "#EXTM3U\r\n#EXT-X-MEDIA:TYPE=AUDIO,NAME=\"en\"\r\n#EXT-X-STREAM-INF:BANDWIDTH=1\r\nv.m3u8\r\n";
+        let out = redux_master(m).into_owned();
+        assert!(out.find("#EXT-X-STREAM-INF").unwrap() < out.find("#EXT-X-MEDIA").unwrap());
+        assert!(!out.contains('\r'), "\\r must be stripped from classified lines");
+    }
+
+    #[test]
+    fn redux_stream_inf_without_uri_at_eof_no_panic() {
+        let m = "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\n";
+        let out = redux_master(m).into_owned();
+        assert!(out.contains("#EXT-X-STREAM-INF:BANDWIDTH=1"));
+    }
+
+    #[test]
+    fn redux_is_idempotent() {
+        let m = "#EXTM3U\n\
+                 #EXT-X-MEDIA:TYPE=AUDIO,NAME=\"en\"\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=6000000\nhigh.m3u8\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=3000000\nlow.m3u8\n\
+                 #EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1,URI=\"if.m3u8\"\n";
+        let once = redux_master(m).into_owned();
+        let twice = redux_master(&once).into_owned();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn redux_already_ordered_master_stays_valid() {
+        let m = "#EXTM3U\n\
+                 #EXT-X-STREAM-INF:BANDWIDTH=1\nv.m3u8\n\
+                 #EXT-X-MEDIA:TYPE=AUDIO,NAME=\"en\"\n";
+        let out = redux_master(m).into_owned();
+        assert!(out.starts_with("#EXTM3U\n"));
+        assert!(out.find("#EXT-X-STREAM-INF").unwrap() < out.find("#EXT-X-MEDIA").unwrap());
+        assert!(out.contains("v.m3u8"));
+        assert!(out.contains("#EXT-X-MEDIA"));
     }
 }

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -367,6 +367,18 @@ pub async fn serve_stream(
         let prefix = format!("{mount_path}/{source}/h/");
         let suffix = build_child_query(token.as_deref(), pl.as_deref(), &stream_entry);
         let RewriteResult { body, hosts, media } = rewrite_manifest(&text_body, &final_url, &prefix, &suffix);
+        // SIR: STREAM-INF Redux — opt-in, ext-mount-only reorder of the rewritten MASTER so the first
+        // #EXT-X-STREAM-INF lands within a strict player's manifest probe window (e.g. VLC's ~8 KiB peek). A pure
+        // post-transform layered OVER rewrite_manifest (unchanged) — a no-op (borrowed) when the flag is off or
+        // the body is a media playlist, so the served bytes are byte-identical to today when off. Ext-mount only:
+        // the in-app player is hls.js (immune, full-string parse) and its /api/v1 path carries no ?pl. Runs BEFORE
+        // the telemetry body.len() below so the reported manifest size reflects what is actually served. hosts +
+        // media are unaffected (Redux adds/removes no URIs), so the SSRF-grow + DEC report below are untouched.
+        let body = if mount_path == "/api/ext/v1" && policy.stream_inf_redux.load(Ordering::Relaxed) {
+            crate::manifest::redux_master(&body).into_owned()
+        } else {
+            body
+        };
         // Grow the source's SSRF allowlist with every host referenced in the manifest (dynamic-allow).
         let grown = hosts.len();
         if !hosts.is_empty() {

--- a/proxy/src/state.rs
+++ b/proxy/src/state.rs
@@ -95,6 +95,10 @@ pub struct SourcePolicy {
     /// P3.2/DST: the distribution output format for this source's streams — "hls" (per-segment passthrough) or
     /// "ts" (continuous raw-TS, honored only on the /api/ext/v1 mount). RwLock<String> so a re-resolve can flip it.
     pub output_format: RwLock<String>,
+    /// SIR: STREAM-INF Redux — opt-in, non-destructive master-playlist reorder (proxy.rs applies it only on the
+    /// /api/ext/v1 mount) so the first #EXT-X-STREAM-INF lands within a strict player's manifest probe window
+    /// (e.g. VLC's ~8 KiB peek). AtomicBool so a re-resolve can flip it; false = today's byte-identical output.
+    pub stream_inf_redux: AtomicBool,
 }
 
 impl SourcePolicy {
@@ -109,6 +113,7 @@ impl SourcePolicy {
             read_timeout_ms: AtomicU64::new(0),
             buffer_size_kb: AtomicU64::new(0),
             output_format: RwLock::new("hls".to_string()),
+            stream_inf_redux: AtomicBool::new(false),
         }
     }
 }
@@ -150,6 +155,10 @@ pub struct ProxyConfigWire {
     pub buffer_size_kb: Option<u64>,
     #[serde(rename = "outputFormat", default = "default_output_format")]
     pub output_format: String,
+    // SIR: STREAM-INF Redux flag. serde `default` → false for a grant from an older Node or an absent key, so
+    // the data plane degrades to today's byte-identical HLS master output.
+    #[serde(rename = "streamInfRedux", default)]
+    pub stream_inf_redux: bool,
 }
 
 fn default_connect_ms() -> u64 {
@@ -170,6 +179,7 @@ impl Default for ProxyConfigWire {
             read_timeout_ms: None,
             buffer_size_kb: None,
             output_format: default_output_format(),
+            stream_inf_redux: false,
         }
     }
 }
@@ -345,6 +355,8 @@ impl AppState {
         policy.read_timeout_ms.store(grant.proxy_config.read_timeout_ms.unwrap_or(0), Ordering::Relaxed);
         policy.buffer_size_kb.store(grant.proxy_config.buffer_size_kb.unwrap_or(0), Ordering::Relaxed);
         *policy.output_format.write().unwrap() = grant.proxy_config.output_format.clone();
+        // SIR: the opt-in master-reorder flag (proxy.rs gates it to the /api/ext/v1 mount).
+        policy.stream_inf_redux.store(grant.proxy_config.stream_inf_redux, Ordering::Relaxed);
         if let Ok(u) = Url::parse(&grant.target) {
             if let Some(h) = u.host_str() {
                 policy.hosts.write().unwrap().insert(h.to_lowercase());
@@ -352,10 +364,11 @@ impl AppState {
         }
         crate::log::info("resolve", &rid, || {
             format!(
-                "grant: target={} relabel={} outputFormat={} connectTimeout={}ms maxRedirects={}",
+                "grant: target={} relabel={} outputFormat={} streamInfRedux={} connectTimeout={}ms maxRedirects={}",
                 crate::proxy::host_of(&grant.target),
                 policy.relabel_segment.read().unwrap().as_deref().unwrap_or("passthrough"),
                 policy.output_format.read().unwrap(),
+                policy.stream_inf_redux.load(Ordering::Relaxed),
                 policy.connect_timeout_ms.load(Ordering::Relaxed),
                 policy.max_redirects.load(Ordering::Relaxed),
             )

--- a/server/src/models/ProxyConfig.ts
+++ b/server/src/models/ProxyConfig.ts
@@ -26,6 +26,9 @@ import { Schema, model } from 'mongoose';
 //   · outputFormat       — distribution shape: 'hls' (segmented) | 'ts' (continuous raw MPEG-TS on the ext
 //                          mount). LIVE (P3.2/DST); enc/fMP4/unreachable falls back to HLS, observable as the
 //                          `delivery` field on Active Streams.
+//   · streamInfRedux     — SIR: opt-in, non-destructive reorder of the HLS MASTER (ext mount only) so the first
+//                          #EXT-X-STREAM-INF lands within a strict player's manifest probe window (e.g. VLC's
+//                          ~8 KiB peek). LIVE; off = today's byte-identical output. See proxy/src/manifest.rs.
 //   · segmentCacheTtlSec — segment cache TTL. RESERVED — the ONE knob still shipped but not yet applied.
 // The reserved knob is stored + surfaced + shipped in the grant but not yet applied — an explicit `null`
 // default marks a not-yet-wired numeric knob (the repo convention).
@@ -38,6 +41,7 @@ export interface ProxyConfigDoc {
   maxRedirects: number; // upstream redirect-follow cap. LIVE in P2.
   headerOverrides: Record<string, string>; // operator upstream-header overrides; merged into the grant. LIVE in P2.
   outputFormat: string; // distribution shape 'hls' (segmented) | 'ts' (continuous raw MPEG-TS, ext mount). LIVE (P3.2/DST); enc/fMP4→HLS.
+  streamInfRedux: boolean; // SIR: opt-in HLS master reorder (ext mount) so the first #EXT-X-STREAM-INF fits a strict player's manifest probe window. LIVE; off = today's output.
   segmentCacheTtlSec: number | null; // segment cache TTL (s); null = no-store (today's behavior). RESERVED (only unapplied knob).
 }
 
@@ -53,6 +57,7 @@ const ProxyConfigSchema = new Schema<ProxyConfigDoc>(
     maxRedirects: { type: Number, required: true, default: 10 },
     headerOverrides: { type: Schema.Types.Mixed, default: {} },
     outputFormat: { type: String, required: true, default: 'hls' },
+    streamInfRedux: { type: Boolean, required: true, default: false },
     segmentCacheTtlSec: { type: Number, default: null },
   },
   { versionKey: false },

--- a/server/src/proxyconfig/translate.ts
+++ b/server/src/proxyconfig/translate.ts
@@ -49,6 +49,7 @@ export function envDefaults(): ProxyConfigData {
     maxRedirects: envInt(process.env.PROXY_MAX_REDIRECTS, 10, 0, 50),
     headerOverrides: {},
     outputFormat: 'hls',
+    streamInfRedux: false,
     segmentCacheTtlSec: null,
   };
 }
@@ -64,6 +65,7 @@ export function toRuntimeProxyConfig(doc: ProxyConfigDoc): RuntimeProxyConfig {
     maxRedirects: typeof doc.maxRedirects === 'number' ? doc.maxRedirects : d.maxRedirects,
     headerOverrides: sanitizeHeaderMap(doc.headerOverrides),
     outputFormat: OUTPUT_FORMATS.includes(doc.outputFormat as (typeof OUTPUT_FORMATS)[number]) ? doc.outputFormat : 'hls',
+    streamInfRedux: typeof doc.streamInfRedux === 'boolean' ? doc.streamInfRedux : false,
     segmentCacheTtlSec: typeof doc.segmentCacheTtlSec === 'number' ? doc.segmentCacheTtlSec : null,
   };
 }
@@ -144,6 +146,14 @@ export function toExternalPatch(body: unknown): PatchResult {
       return { ok: false, error: `outputFormat (one of: ${OUTPUT_FORMATS.join(', ')}) required` };
     }
     $set.outputFormat = v;
+  }
+
+  // streamInfRedux: SIR opt-in flag — a plain boolean (mirrors the outputFormat gate above).
+  if (b.streamInfRedux !== undefined) {
+    if (typeof b.streamInfRedux !== 'boolean') {
+      return { ok: false, error: 'streamInfRedux (boolean) required' };
+    }
+    $set.streamInfRedux = b.streamInfRedux;
   }
 
   // headerOverrides: an object of header-name -> string value. An empty object clears all overrides. Reject a

--- a/src/components/ProxyConfigPanel.vue
+++ b/src/components/ProxyConfigPanel.vue
@@ -12,6 +12,7 @@ import { ref, onMounted, watch } from 'vue';
 import Icon from './Icon.vue';
 import Btn from './Btn.vue';
 import Segmented from './Segmented.vue';
+import Toggle from './Toggle.vue';
 import { useProxyConfig } from '../composables/useProxyConfig';
 
 const props = defineProps<{ configId: string; title?: string; flat?: boolean }>();
@@ -137,17 +138,32 @@ watch(
         </div>
       </div>
 
-      <div class="form-row" style="margin-top: 14px;">
-        <div class="field-lbl">Output format</div>
-        <Segmented
-          :value="state.outputFormat"
-          @change="(v) => (state.outputFormat = v)"
-          :options="[{ value: 'hls', label: 'HLS' }, { value: 'ts', label: 'Raw TS' }]"
-        />
-        <div class="muted" style="font-size: var(--fs-xs); margin-top: 6px;">
-          How streams reach third-party players (the in-app player is always HLS). <b>HLS</b> rewrites the
-          playlist per segment; <b>Raw TS</b> serves one continuous MPEG-TS stream for clients that prefer it
-          (pure-TS sources only — encrypted / fMP4 upstreams fall back to HLS automatically).
+      <!-- Output format shares a 2-col row with STREAM-INF Redux (it shrinks to the left half). -->
+      <div class="form-grid-2" style="margin-top: 14px;">
+        <div class="form-row">
+          <div class="field-lbl">Output format</div>
+          <Segmented
+            :value="state.outputFormat"
+            @change="(v) => (state.outputFormat = v)"
+            :options="[{ value: 'hls', label: 'HLS' }, { value: 'ts', label: 'Raw TS' }]"
+          />
+          <div class="muted" style="font-size: var(--fs-xs); margin-top: 6px;">
+            How streams reach third-party players (the in-app player is always HLS). <b>HLS</b> rewrites the
+            playlist per segment; <b>Raw TS</b> serves one continuous MPEG-TS stream for clients that prefer it
+            (pure-TS sources only — encrypted / fMP4 upstreams fall back to HLS automatically).
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="field-lbl">STREAM-INF Redux</div>
+          <div class="row" style="align-items: center; gap: 10px;">
+            <Toggle :on="state.streamInfRedux" @change="(v) => (state.streamInfRedux = v)" />
+            <span class="muted" style="font-size: var(--fs-xs);">{{ state.streamInfRedux ? 'On' : 'Off' }}</span>
+          </div>
+          <div class="muted" style="font-size: var(--fs-xs); margin-top: 6px;">
+            Reorders the HLS master so the first <span class="mono">#EXT-X-STREAM-INF</span> lands in the first
+            few KB, letting strict third-party players (e.g. VLC's 8&nbsp;KB probe) detect it as HLS.
+            External-player mount only; keeps every variant &amp; rendition. No effect on the in-app player or Raw TS.
+          </div>
         </div>
       </div>
 

--- a/src/composables/useProxyConfig.ts
+++ b/src/composables/useProxyConfig.ts
@@ -16,6 +16,7 @@ export interface ProxyConfigState {
   maxRedirects: number; // LIVE in P2 (Rust upstream redirect cap)
   headerOverrides: Record<string, string>; // LIVE in P2 (merged into the grant's upstream headers)
   outputFormat: string; // LIVE (P3.2/DST) — 'hls' (segmented) | 'ts' (continuous raw MPEG-TS, ext mount); enc/fMP4→HLS
+  streamInfRedux: boolean; // LIVE (SIR) — opt-in HLS master reorder (ext mount) so the first #EXT-X-STREAM-INF fits a strict player's probe window
   segmentCacheTtlSec: number | null; // reserved (the only unapplied knob)
 }
 
@@ -31,6 +32,7 @@ export function proxyConfigDefaults(): ProxyConfigState {
     maxRedirects: 10,
     headerOverrides: {},
     outputFormat: 'hls',
+    streamInfRedux: false,
     segmentCacheTtlSec: null,
   };
 }
@@ -49,6 +51,7 @@ function normalize(raw: unknown): ProxyConfigState {
         ? { ...(s.headerOverrides as Record<string, string>) }
         : {},
     outputFormat: typeof s.outputFormat === 'string' ? s.outputFormat : d.outputFormat,
+    streamInfRedux: typeof s.streamInfRedux === 'boolean' ? s.streamInfRedux : false,
     segmentCacheTtlSec: typeof s.segmentCacheTtlSec === 'number' ? s.segmentCacheTtlSec : null,
   };
 }


### PR DESCRIPTION
- "Reduce size" is achieved by relocation, not deletion — you chose this (non-destructive) explicitly. Total bytes are essentially unchanged; the marker just moves into the window.
- Root cause is the e=<full entry URL> suffix repeated per line (~300–600 B). The strategic long-term shrink (short opaque hop-id) would touch the working delivery path, so it's out of scope here — recommended as a follow-up.
- Residual (astronomically unlikely): a single STREAM-INF+URI line exceeding 8192 B (needs a ~7,500-char entry URL) — reorder can't fix that.

Ref issue #18 