### PR TITLE
feat(upl): sort the Ultimate Player channel list by name or channel n…

### DIFF
--- a/src/docs/settings.md
+++ b/src/docs/settings.md
@@ -30,11 +30,15 @@ and the **Custom Tags** manager. Changes save to the single application settings
     and guide for the playlist you launched from, a channel switcher you can pull out from the right edge,
     and a **what's on now / next** strip under the picture. Best when you actually want to *watch* a
     channel rather than glance at it. Allow pop-ups for this site or the window can't open.
-    Sound is on by default and your volume / mute choice is remembered between channels and windows. If the
-    browser blocks audio on load — most do, until you've interacted with the page — the picture says so and
-    one click on that banner (or the **M** key) turns sound on. The window opens without a tab strip,
-    toolbar or bookmarks bar; the thin strip showing the site address is forced on by the browser itself and
-    can't be turned off from the app, so use **Full screen** (or the **F** key) for a completely bare window.
+    The channel switcher lists channels **A–Z by name**; the **A–Z** button in its header flips it to
+    **channel-number** order (**#**), with unnumbered channels last. Channel numbers come from the provider
+    and are often meaningless in a clone playlist, which is why name order is the default; your choice is
+    remembered in this browser. Sound is on by default and your volume / mute choice is remembered between
+    channels and windows. If the browser blocks audio on load — most do, until you've interacted with the
+    page — the picture says so and one click on that banner (or the **M** key) turns sound on. The window
+    opens without a tab strip, toolbar or bookmarks bar; the thin strip showing the site address is forced
+    on by the browser itself and can't be turned off from the app, so use **Full screen** (or the **F** key)
+    for a completely bare window.
   - **Debug video player** — adds a live hls.js status readout and event log. Reach for it only when a
     channel won't play; it shows exactly where the stream stalls.
 

--- a/src/upl/UplChannelRail.vue
+++ b/src/upl/UplChannelRail.vue
@@ -15,7 +15,7 @@ import type { Channel, Program } from '../data';
 import ChannelLogo from '../components/ChannelLogo.vue';
 import Icon from '../components/Icon.vue';
 import { useVirtualList } from '../composables/useVirtualList';
-import { now, nowNext, progressOf, epgKey, fmtClock, fmtRemaining } from './useUplData';
+import { now, nowNext, progressOf, epgKey, fmtClock, fmtRemaining, sortKey } from './useUplData';
 
 const ROW_H = 58; // MUST match .upl-rail-row height in CSS — useVirtualList is pure arithmetic on this
 
@@ -74,6 +74,10 @@ watch(sliceRows, (rows) => emit('visibleKeys', rows.map((r) => epgKey(r.ch))), {
 
 // Reset the virtual window when the filter changes the list out from under it.
 watch(shown, () => { void nextTick(() => vl.measure()); });
+// A reorder moves every index, so the cursor must be re-pinned to what is actually playing. Deliberately NOT
+// folded into the watcher above: that one also fires on every filter keystroke, where yanking the cursor back
+// to the playing channel would fight the person typing.
+watch(sortKey, () => { void nextTick(() => syncCursorToCurrent()); });
 
 // --- keyboard cursor movement, driven by the parent's global keymap ------------------------------------
 function move(delta: number): void {
@@ -113,6 +117,18 @@ defineExpose({ move, tuneCursor });
       <Icon name="tv" :size="14" />
       <span class="upl-rail-count mono">{{ shown.length }}</span>
       <input v-model="filter" class="input upl-rail-search" placeholder="Filter channels…" />
+      <!-- Sort toggle. A pressed-state text button rather than a Segmented, mirroring the Playlists screen's
+           A-Z button: the rail is only 340px wide and the filter box owns flex:1. -->
+      <button
+        type="button"
+        class="upl-rail-sort"
+        :class="{ 'is-active': sortKey === 'name' }"
+        :aria-pressed="sortKey === 'name' ? 'true' : 'false'"
+        :title="sortKey === 'name'
+          ? 'Sorted by channel name — switch to channel number order'
+          : 'Sorted by channel number — switch to A–Z'"
+        @click="sortKey = sortKey === 'name' ? 'channelNo' : 'name'"
+      >{{ sortKey === 'name' ? 'A–Z' : '#' }}</button>
       <button type="button" class="upl-rail-close" aria-label="Hide channels" @click="emit('update:open', false)">
         <Icon name="x" :size="14" />
       </button>
@@ -130,7 +146,9 @@ defineExpose({ move, tuneCursor });
             @click="emit('tune', row.ch)"
           >
             <ChannelLogo :ch="row.ch" />
-            <span class="upl-rail-no mono">{{ row.ch.channelNo ?? '—' }}</span>
+            <!-- `||`, not `??`: a blank channelNo is unnumbered as far as this rail is concerned (the sort
+                 treats it as such), so it reads '—' like a null one instead of leaving a gap in the column. -->
+            <span class="upl-rail-no mono">{{ row.ch.channelNo || '—' }}</span>
             <span class="upl-rail-body">
               <span class="upl-rail-name">{{ row.ch.tvg_name }}</span>
               <span class="upl-rail-epg mono">
@@ -200,6 +218,23 @@ defineExpose({ move, tuneCursor });
   cursor: pointer;
 }
 .upl-rail-close:hover { color: var(--text-0); background: oklch(1 0 0 / 0.06); }
+/* Same metrics as the close button, but text-width rather than square (the label is 'A-Z' or '#'). */
+.upl-rail-sort {
+  display: grid;
+  place-items: center;
+  height: 24px;
+  padding: 0 6px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-3);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.upl-rail-sort:hover { color: var(--text-0); background: oklch(1 0 0 / 0.06); }
+.upl-rail-sort.is-active { color: var(--accent); }
 
 .upl-rail-list { flex: 1; min-height: 0; overflow-y: auto; }
 

--- a/src/upl/useUplData.ts
+++ b/src/upl/useUplData.ts
@@ -18,7 +18,7 @@
 //             the one being watched. Tiny payload, so the rich projection costs nothing here.
 // They write to SEPARATE caches so a lean rail fetch can never clobber the rich data the strip is showing.
 
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import type { Channel, Program } from '../data';
 
 const HOUR_MS = 3_600_000;
@@ -227,12 +227,56 @@ export function fmtEpisode(p: Program | null): string {
   return [s, e].filter(Boolean).join(' ');
 }
 
-// Channel-number-ordered list for the rail. The API sorts by (group, name); a player wants channel order,
-// with unnumbered channels last but still reachable.
+// ---------------------------------------------------------------------------------------------------
+// Rail sort order — a per-device viewer preference, not an operator setting.
+// ---------------------------------------------------------------------------------------------------
+// Persisted exactly like the volume/mute choice (UplVideoJsPlayer's `upl:audio`): same `upl:` namespace, same
+// defensive read, same silent fallback when storage is blocked. Deliberately NOT a Settings field — this
+// bundle never fetches /api/settings, and importing useSettings would drag data.ts into the popup.
+const SORT_PREF_KEY = 'upl:sort';
+export type UplSortKey = 'name' | 'channelNo';
+
+function loadSortPref(): UplSortKey {
+  try {
+    const raw = localStorage.getItem(SORT_PREF_KEY);
+    if (raw === 'name' || raw === 'channelNo') return raw;
+  } catch { /* private mode / storage blocked — fall through to the default */ }
+  return 'name';
+}
+
+// Default is NAME, not number. Channel numbers are inherited verbatim from the upstream provider and are
+// frequently meaningless in a clone playlist (issue #51: 600000 sitting next to 6065), whereas the name always
+// means something. Most playlists carry no number at all, so for them this is the order the rail already had.
+export const sortKey = ref<UplSortKey>(loadSortPref());
+
+watch(sortKey, (k) => {
+  try { localStorage.setItem(SORT_PREF_KEY, k); } catch { /* a lost preference is not worth throwing over */ }
+});
+
+// The rail's flat, ordered list. The API sorts by (group, tvg_name); a player wants ONE list in the viewer's
+// chosen order, so the grouping is discarded here and the sort is redone client-side.
 export const orderedChannels = computed<Channel[]>(() => {
-  const n = (c: Channel) => {
-    const v = Number(c.channelNo);
-    return Number.isFinite(v) ? v : Number.POSITIVE_INFINITY;
-  };
-  return [...channels.value].sort((a, b) => n(a) - n(b) || a.tvg_name.localeCompare(b.tvg_name));
+  const byName = (a: Channel, b: Channel) => a.tvg_name.localeCompare(b.tvg_name);
+  const rows = [...channels.value];
+  if (sortKey.value === 'name') return rows.sort(byName);
+  // channelNo is a user-editable nullable STRING ('101', '4.1', '12A', '', null). Compare numerically when
+  // both sides parse, else lexically, with unnumbered channels LAST — the rule the Playlist detail table's
+  // "Channel No" sort already uses (PlaylistDetailScreen.vue), plus the blank-is-unnumbered guard below.
+  // parseFloat (not Number) is load-bearing: it reads the leading number, so a '12A' subchannel sorts next
+  // to 12 rather than being exiled with the unparseable ones.
+  //
+  // The previous `Number(c.channelNo)` here sorted unnumbered channels FIRST, against the comment that sat
+  // above it: Number(null) is 0, not NaN.
+  return rows.sort((a, b) => {
+    // Blank counts as unnumbered. ChannelDrawer normalizes '' back to null on save, but a sync or an import
+    // can still seed an empty string, and '' would otherwise lexically outrank every real channel number.
+    const an = a.channelNo?.trim() || null;
+    const bn = b.channelNo?.trim() || null;
+    if (an == null && bn == null) return byName(a, b);
+    if (an == null) return 1;
+    if (bn == null) return -1;
+    const af = parseFloat(an), bf = parseFloat(bn);
+    const bothNum = !Number.isNaN(af) && !Number.isNaN(bf);
+    return (bothNum ? af - bf : an.localeCompare(bn)) || byName(a, b);
+  });
 });


### PR DESCRIPTION
…umber

Closes #51.

The rail's order came from a single computed (useUplData.orderedChannels) that always sorted by channel number, with the name only as a tiebreak. That explains every symptom in the issue thread:

  - "all the playlists EXCEPT localnow have been alphabetized" — most built-in sources never populate channelNo, so every row tied on the number key and fell through to the name tiebreak. The rail looked alphabetical by accident.
  - "it's not sorting the custom playlist I added" — a clone inherits each channel's number from its original source (00s Replay = 600000 sitting next to 6065), so the numeric key dominated and the list looked shuffled.

Adds an A-Z / # toggle to the channel rail header, defaulting to NAME order. The choice is a per-device viewer preference persisted under 'upl:sort', following UplVideoJsPlayer's existing 'upl:audio' pattern — same namespace, same defensive read, same silent fallback when storage is blocked. Deliberately not a Settings field: this bundle never fetches /api/settings, and importing useSettings would drag data.ts into the popup.

The channelNo comparator is the one the Playlist detail table already uses (numeric when both sides parse, else lexical, unnumbered last), which fixes two latent bugs in the old expression — both of which put unnumbered channels FIRST, directly against the comment that sat above it:

  - Number(null) is 0, not NaN, so a null channelNo sorted ahead of channel 1.
  - '' is not null, so a blank channelNo lexically outranked every real number.

Blank now counts as unnumbered in both the sort and the display ('—', matching a null one, instead of leaving a gap in the column). parseFloat rather than Number is load-bearing: it reads the leading number, so a '12A' subchannel sorts next to 12 instead of being exiled with the unparseable values.

A reorder moves every list index, so the rail re-pins its keyboard cursor to the playing channel on a sort change — as a watcher separate from the existing re-measure, which also fires on every filter keystroke, where yanking the cursor back would fight the person typing.

No server change. GET /api/playlists/:id/channels keeps its index-backed .sort({ group: 1, tvg_name: 1 }), which m3u/compose.ts deliberately mirrors for the .m3u export; the player re-sorts client-side instead.

Verified: `npm run build` (vue-tsc + vite) passes. Both orders, the persistence, the cursor re-pin, the filter-does-not-move-the-cursor guard, the 340px header layout and both themes were exercised in-browser against the real components, using the issue's own channel numbers.